### PR TITLE
Allow running tests on Windows

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -58,6 +58,8 @@ module.exports.getSourceType = function (source) {
   if (!_.isString(source))
     return undefined;
 
+  if (FS.existsSync(source))
+    return 'file'; // windows resolved paths look like absolute URLs
   var uri = new URI(source);
   if (uri.is('absolute'))
     return 'url';


### PR DESCRIPTION
Checking for whether a path looks like an absolute URI is problematic on Windows as the drive letter specifier looks like a protocol declaration. So, we simply check for local file existence first.