### PR TITLE
Yaml output

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,22 @@ $ api-spec-converter -h
 
   Options:
 
-    -h, --help           output usage information
-    -V, --version        output the version number
-    -f, --from <format>  Specifies format to convert
-    -t, --to <format>    Specifies output format
-    -c, --check          Check if result is valid spec
-    -d, --dummy          Fill missing required fields with dummy data
+    -h, --help            output usage information
+    -V, --version         output the version number
+    -f, --from <format>   Specifies format to convert
+    -t, --to <format>     Specifies output format
+    -s, --syntax <syntax> Specifies output data syntax: json or yaml. Defaults to json
+    -c, --check           Check if result is valid spec
+    -d, --dummy           Fill missing required fields with dummy data
 ```
 
 Example:
 ```bash
+# Json output
 $ api-spec-converter https://api.gettyimages.com/swagger/api-docs --from=swagger_1 --to=swagger_2 > swagger.json
+
+# Yaml output
+$ api-spec-converter https://api.gettyimages.com/swagger/api-docs --from=swagger_1 --to=swagger_2 -syntax=yaml > swagger.yaml
 ```
 
 ### NodeJS
@@ -78,6 +83,8 @@ Converter.convert({
   source: 'https://api.gettyimages.com/swagger/api-docs',
 }, function(err, converted) {
   console.log(converted.stringify());
+  // For yaml output replace above line with
+  // console.log(converted.stringify('yaml'));
 })
 ```
 ### Callback vs Promises

--- a/bin/api-spec-converter
+++ b/bin/api-spec-converter
@@ -15,6 +15,7 @@ Program
               )
   .option('-f, --from <format>', 'Specifies format to convert')
   .option('-t, --to <format>', 'Specifies output format')
+  .option('-s, --syntax <outputSyntax>', 'Specifies output data syntax: json or yaml')
   .option('-c, --check', 'Check if result is valid spec')
   .option('-d, --dummy', 'Fill missing required fields with dummy data')
   .arguments('<URL|filename>')
@@ -33,7 +34,7 @@ function main(url, options) {
     from: options.from,
     to: options.to
   }).then(function (spec) {
-    console.log(spec.stringify())
+    console.log(spec.stringify(options.syntax))
     if (!options.check)
       return;
     return spec.validate()

--- a/lib/base_format.js
+++ b/lib/base_format.js
@@ -15,7 +15,9 @@ var BaseFormat = module.exports = function(spec) {
   this.converters = {};
 }
 
-BaseFormat.prototype.stringify = function(syntax = 'json') {
+BaseFormat.prototype.stringify = function(syntax) {
+  // for backard compatibility default to json if syntax argument is not provided
+  syntax = syntax || 'json';
   var sortedSpecs = SortObject(this.spec, function (a, b) {
     //By default sort is done using local aware compare
     //Instead using order that will never change

--- a/lib/base_format.js
+++ b/lib/base_format.js
@@ -7,6 +7,7 @@ var CompositeError = require('composite-error');
 
 var Formats = require('./formats.js');
 var Util = require('./util.js');
+var Yaml = require('js-yaml');
 
 var BaseFormat = module.exports = function(spec) {
   if (spec) this.spec = spec;
@@ -14,15 +15,20 @@ var BaseFormat = module.exports = function(spec) {
   this.converters = {};
 }
 
-BaseFormat.prototype.stringify = function() {
-  var json = SortObject(this.spec, function (a, b) {
+BaseFormat.prototype.stringify = function(syntax = 'json') {
+  var sortedSpecs = SortObject(this.spec, function (a, b) {
     //By default sort is done using local aware compare
     //Instead using order that will never change
     if (a === b)
       return 0;
     return (a < b) ? -1 : 1;
   });
-  return JSON.stringify(json, null, 2);
+
+  if (syntax == "yaml") {
+    return Yaml.safeDump(sortedSpecs)
+  } else {
+    return JSON.stringify(sortedSpecs, null, 2);
+  }
 }
 
 BaseFormat.prototype.parsers = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-spec-converter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "engines": {
     "node": "^4.2.0"
   },

--- a/test/convert.js
+++ b/test/convert.js
@@ -44,3 +44,42 @@ describe('Converter', function() {
     })
   })
 });
+
+
+// The "Converter" test suite above validates that all conversions are as expected.
+// It cocuses on validating that the JavaScript object has the right content.
+// It does not check how the object is Marshalled out.
+//
+// The "Converter & Output Syntax" suite run a few similar tests
+// but focuses on validating that the output is json or yaml.
+describe('Converter & Output Syntax', function() {
+  this.timeout(10000);
+  SyntaxTestCases.forEach(function(testCase) {
+    var testName = 'should convert ' + testCase.in.file +
+      ' from ' + testCase.in.format + ' to ' + testCase.out.format +
+      ' and ouput as ' + testCase.out.syntax;
+
+    it(testName, function(done) {
+      convertFile(testCase)
+        .then(function(spec) {
+          var specAsString = spec.stringify(testCase.out.syntax) + '\n'
+          var outfile = getFileName('output', testCase.out);
+
+          if (WRITE_GOLDEN)
+            FS.writeFileSync(outfile, specAsString);
+
+          getFileRaw(outfile, function(err, goldenString) {
+            try {
+            expect(specAsString).to.deep.equal(goldenString);
+            } catch(e) {
+              return done(e);
+            }
+            done();
+          });
+        })
+        .catch(function (e) {
+           done(e);
+        });
+    })
+  })
+});

--- a/test/output/swagger_2/petstore.yaml
+++ b/test/output/swagger_2/petstore.yaml
@@ -1,0 +1,683 @@
+basePath: /api
+definitions:
+  Animal:
+    discriminator: type
+    properties:
+      id:
+        type: integer
+      type:
+        type: string
+    required:
+      - id
+      - type
+  Cat:
+    allOf:
+      - properties:
+          likesMilk:
+            type: boolean
+        required:
+          - likesMilk
+      - $ref: '#/definitions/Animal'
+  Category:
+    properties:
+      id:
+        format: int64
+        type: integer
+      name:
+        type: string
+  Order:
+    properties:
+      id:
+        format: int64
+        type: integer
+      petId:
+        format: int64
+        type: integer
+      quantity:
+        format: int32
+        type: integer
+      shipDate:
+        format: date-time
+        type: string
+      status:
+        description: Order Status
+        enum:
+          - placed
+          - ' approved'
+          - ' delivered'
+        type: string
+  Pet:
+    properties:
+      category:
+        $ref: '#/definitions/Category'
+      id:
+        default: 1
+        description: unique identifier for the pet
+        format: int64
+        maximum: 100
+        minimum: 0
+        type: integer
+      name:
+        type: string
+      photoUrls:
+        items:
+          type: string
+        type: array
+      status:
+        description: pet status in the store
+        enum:
+          - available
+          - pending
+          - sold
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/Tag'
+        type: array
+    required:
+      - id
+      - name
+  Tag:
+    properties:
+      id:
+        format: int64
+        type: integer
+      name:
+        type: string
+  User:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      id:
+        format: int64
+        type: integer
+      lastName:
+        type: string
+      password:
+        type: string
+      phone:
+        type: string
+      userStatus:
+        description: User Status
+        enum:
+          - 1-registered
+          - 2-active
+          - 3-closed
+        format: int32
+        type: integer
+      username:
+        type: string
+host: petstore.swagger.wordnik.com
+info:
+  contact:
+    email: apiteam@wordnik.com
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger 
+        at <a href="http://swagger.wordnik.com">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,
+        you can use the api key "special-key" to test the authorization filters
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  termsOfService: 'http://helloreverb.com/terms/'
+  title: Swagger Sample App
+  version: 1.0.0
+paths:
+  /pet:
+    put:
+      operationId: updatePet
+      parameters:
+        - description: Pet object that needs to be updated in the store
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/Pet'
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      summary: Update an existing pet
+      tags:
+        - pet
+  /pet/findByStatus:
+    get:
+      description: Multiple status values can be provided with comma seperated strings
+      operationId: findPetsByStatus
+      parameters:
+        - description: Status values that need to be considered for filter
+          in: query
+          items:
+            enum:
+              - available
+              - pending
+              - sold
+            type: string
+          name: status
+          required: true
+          type: array
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            items:
+              $ref: '#/definitions/Pet'
+            type: array
+        '400':
+          description: Invalid status value
+      summary: Finds Pets by status
+      tags:
+        - pet
+  /pet/findByTags:
+    get:
+      deprecated: true
+      description: >-
+        Muliple tags can be provided with comma seperated strings. Use tag1,
+        tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - description: Tags to filter by
+          in: query
+          items:
+            type: string
+          name: tags
+          required: true
+          type: array
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            items:
+              $ref: '#/definitions/Pet'
+            type: array
+        '400':
+          description: Invalid tag value
+      summary: Finds Pets by tags
+      tags:
+        - pet
+  /pet/uploadImage:
+    post:
+      consumes:
+        - multipart/form-data
+      operationId: uploadFile
+      parameters:
+        - description: Additional data to pass to server
+          in: formData
+          name: additionalMetadata
+          required: false
+          type: string
+        - description: file to upload
+          in: formData
+          name: file
+          required: false
+          type: file
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+      security:
+        - oauth2_accessCode:
+            - 'write:pets'
+            - 'read:pets'
+        - oauth2_implicit:
+            - 'write:pets'
+            - 'read:pets'
+      summary: uploads an image
+      tags:
+        - pet
+  '/pet/{petId}':
+    delete:
+      operationId: deletePet
+      parameters:
+        - description: Pet id to delete
+          in: path
+          name: petId
+          required: true
+          type: string
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+        '400':
+          description: Invalid pet value
+      security:
+        - oauth2_accessCode:
+            - 'write:pets'
+        - oauth2_implicit:
+            - 'write:pets'
+      summary: Deletes a pet
+      tags:
+        - pet
+    get:
+      description: Returns a pet based on ID
+      operationId: getPetById
+      parameters:
+        - default: 1
+          description: ID of pet that needs to be fetched
+          format: int64
+          in: path
+          maximum: 100000
+          minimum: 1
+          name: petId
+          required: true
+          type: integer
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            $ref: '#/definitions/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      summary: Find pet by ID
+      tags:
+        - pet
+    patch:
+      consumes:
+        - application/json
+        - application/xml
+      operationId: partialUpdate
+      parameters:
+        - description: ID of pet that needs to be fetched
+          in: path
+          name: petId
+          required: true
+          type: string
+        - description: Pet object that needs to be added to the store
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/Pet'
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            items:
+              $ref: '#/definitions/Pet'
+            type: array
+        '400':
+          description: Invalid tag value
+      security:
+        - oauth2_accessCode:
+            - 'write:pets'
+        - oauth2_implicit:
+            - 'write:pets'
+      summary: partial updates to a pet
+      tags:
+        - pet
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      operationId: updatePetWithForm
+      parameters:
+        - description: ID of pet that needs to be updated
+          in: path
+          name: petId
+          required: true
+          type: string
+        - description: Updated name of the pet
+          in: formData
+          name: name
+          required: false
+          type: string
+        - description: Updated status of the pet
+          in: formData
+          name: status
+          required: false
+          type: string
+      produces:
+        - application/json
+        - application/xml
+        - text/plain
+        - text/html
+      responses:
+        '200':
+          description: No response was specified
+        '405':
+          description: Invalid input
+      security:
+        - oauth2_accessCode:
+            - 'write:pets'
+        - oauth2_implicit:
+            - 'write:pets'
+      summary: Updates a pet in the store with form data
+      tags:
+        - pet
+  /store/order:
+    post:
+      operationId: placeOrder
+      parameters:
+        - description: order placed for purchasing the pet
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/Order'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+        '400':
+          description: Invalid order
+      security:
+        - oauth2_accessCode:
+            - 'write:pets'
+        - oauth2_implicit:
+            - 'write:pets'
+      summary: Place an order for a pet
+      tags:
+        - store
+  '/store/order/{orderId}':
+    delete:
+      description: >-
+        For valid response try integer IDs with value < 1000.  Anything above
+        1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - description: ID of the order that needs to be deleted
+          in: path
+          name: orderId
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+      security:
+        - oauth2_accessCode:
+            - 'write:pets'
+        - oauth2_implicit:
+            - 'write:pets'
+      summary: Delete purchase order by ID
+      tags:
+        - store
+    get:
+      description: >-
+        For valid response try integer IDs with value <= 5. Anything above 5 or
+        nonintegers will generate API errors
+      operationId: getOrderById
+      parameters:
+        - description: ID of pet that needs to be fetched
+          in: path
+          name: orderId
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            $ref: '#/definitions/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+      summary: Find purchase order by ID
+      tags:
+        - store
+  /user:
+    post:
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      parameters:
+        - description: Created user object
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/User'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+      security:
+        - oauth2_accessCode:
+            - 'test:anything'
+        - oauth2_implicit:
+            - 'test:anything'
+      summary: Create user
+      tags:
+        - user
+  /user/createWithArray:
+    post:
+      operationId: createUsersWithArrayInput
+      parameters:
+        - description: List of user object
+          in: body
+          name: body
+          required: true
+          schema:
+            items:
+              $ref: '#/definitions/User'
+            type: array
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+      security:
+        - oauth2_accessCode:
+            - 'test:anything'
+        - oauth2_implicit:
+            - 'test:anything'
+      summary: Creates list of users with given input array
+      tags:
+        - user
+  /user/createWithList:
+    post:
+      operationId: createUsersWithListInput
+      parameters:
+        - description: List of user object
+          in: body
+          name: body
+          required: true
+          schema:
+            items:
+              $ref: '#/definitions/User'
+            type: array
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+      security:
+        - oauth2_accessCode:
+            - 'test:anything'
+        - oauth2_implicit:
+            - 'test:anything'
+      summary: Creates list of users with given list input
+      tags:
+        - user
+  /user/login:
+    get:
+      operationId: loginUser
+      parameters:
+        - description: The user name for login
+          in: query
+          name: username
+          required: true
+          type: string
+        - description: The password for login in clear text
+          in: query
+          name: password
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            type: string
+        '400':
+          description: Invalid username and password combination
+      summary: Logs user into the system
+      tags:
+        - user
+  /user/logout:
+    get:
+      operationId: logoutUser
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+      summary: Logs out current logged in user session
+      tags:
+        - user
+  '/user/{username}':
+    delete:
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - description: The name that needs to be deleted
+          in: path
+          name: username
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      security:
+        - oauth2_accessCode:
+            - 'test:anything'
+        - oauth2_implicit:
+            - 'test:anything'
+      summary: Delete user
+      tags:
+        - user
+    get:
+      operationId: getUserByName
+      parameters:
+        - description: The name that needs to be fetched. Use user1 for testing.
+          in: path
+          name: username
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+          schema:
+            $ref: '#/definitions/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      summary: Get user by user name
+      tags:
+        - user
+    put:
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - description: name that need to be deleted
+          in: path
+          name: username
+          required: true
+          type: string
+        - description: Updated user object
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/User'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: No response was specified
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      security:
+        - oauth2_accessCode:
+            - 'test:anything'
+        - oauth2_implicit:
+            - 'test:anything'
+      summary: Updated user
+      tags:
+        - user
+schemes:
+  - http
+securityDefinitions:
+  oauth2_accessCode:
+    authorizationUrl: 'http://petstore.swagger.wordnik.com/api/oauth/requestToken'
+    flow: accessCode
+    scopes:
+      'read:pets': Read your pets
+      'write:pets': Modify pets in your account
+    tokenUrl: 'http://petstore.swagger.wordnik.com/api/oauth/token'
+    type: oauth2
+  oauth2_implicit:
+    authorizationUrl: 'http://petstore.swagger.wordnik.com/api/oauth/dialog'
+    flow: implicit
+    scopes:
+      'read:pets': Read your pets
+      'write:pets': Modify pets in your account
+    type: oauth2
+swagger: '2.0'
+tags:
+  - description: Operations about pets
+    name: pet
+  - description: Operations about store
+    name: store
+  - description: Operations about user
+    name: user
+

--- a/test/setup/browser.js
+++ b/test/setup/browser.js
@@ -7,12 +7,26 @@ window.getFileName = function(dir, testCaseItem) {
   return host + '/test/' + dir + '/' + file;
 }
 
+// returns file content as a JavaScript
 window.getFile = function(file, cb) {
   var xobj = new XMLHttpRequest();
   xobj.open('GET', file, true);
   xobj.onload = function () {
     if (xobj.status === 200)
       cb(null, JSON.parse(xobj.response));
+    else
+      cb(Error(xobj.status + ': Failed to load ' + file));
+  };
+  xobj.send(null);
+}
+
+// returns file content as a string
+window.getFileRaw = function(file, cb) {
+  var xobj = new XMLHttpRequest();
+  xobj.open('GET', file, true);
+  xobj.onload = function () {
+    if (xobj.status === 200)
+      cb(null, xobj.response);
     else
       cb(Error(xobj.status + ': Failed to load ' + file));
   };

--- a/test/setup/node.js
+++ b/test/setup/node.js
@@ -5,9 +5,15 @@ global.getFileName = function(dir, testCase) {
   return path.join(__dirname, '..', dir, testCase.format, testCase.directory || '', testCase.file);
 }
 
+// returns file content as a JavaScript
 global.getFile = function(file, cb) {
   var res = JSON.parse(fs.readFileSync(file, 'utf8'));
   cb(null, res);
+}
+
+// returns file content as a string
+global.getFileRaw = function(file, cb) {
+  cb(null, fs.readFileSync(file, 'utf8'));
 }
 
 global.expect = require('chai').expect;
@@ -16,4 +22,7 @@ global.FS = fs;
 global.WRITE_GOLDEN = process.env.WRITE_GOLDEN;
 global.Converter = require('../../index.js');
 
-global.TestCases = require('./../test-cases.js');
+global.TestSuites      = require('./../test-cases.js');
+global.TestCases       = TestSuites.TestCases;
+global.SyntaxTestCases = TestSuites.SyntaxTestCases;
+

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -58,8 +58,26 @@ TestCases.push({
   out: {format: 'swagger_2', file: 'XKCD.json'}
 })
 
+//------------------ Json & Yaml test cases -------------------
+
+var SyntaxTestCases = []
+
+SyntaxTestCases.push({
+  in: {format: 'swagger_1', directory: 'petstore', file: 'index.json'},
+  out: {format: 'swagger_2', file: 'petstore.json', syntax: 'json'}
+})
+
+SyntaxTestCases.push({
+  in: {format: 'swagger_1', directory: 'petstore', file: 'index.json'},
+  out: {format: 'swagger_2', file: 'petstore.yaml', syntax: 'yaml'}
+})
+
+//---- exports ----
+
 if (typeof module !== 'undefined') {
-  module.exports = TestCases;
+  module.exports = {TestCases: TestCases, SyntaxTestCases: SyntaxTestCases};
 } else {
+  // TODO I could not test this branch.
+  // It should probably be updated to look like the one in the module block above
   window.TestCases = TestCases;
 }


### PR DESCRIPTION
Added a command line option, and argument to spec.stringify, 
to allow spec output to be json or yaml formatted.

I would have called this option "format" but since this word is already heavily
used in this library to indicate the  different types of specification supported,
I used the word "syntax" to refer to the json and yaml format.
I'm open to suggestion if you have a better term!

I have added 2 test cases to validate the actual output.
The current test suites only focused on testing the conversion.

I'm new to JavaScript, so I hope the way I modified the code is reasonable!