### PR TITLE
Support Sway jsonRefs and definition.remotesResolved

### DIFF
--- a/lib/formats/swagger_2.js
+++ b/lib/formats/swagger_2.js
@@ -72,9 +72,11 @@ Swagger2.prototype.checkFormat = function (spec) {
 }
 
 Swagger2.prototype.validate = function (callback) {
-  var promise = sway.create({definition: this.spec})
+  var promise = sway.create({definition: this.spec, jsonRefs: this.jsonRefs})
     .then(function (swaggerObj) {
       var result = swaggerObj.validate();
+
+      result.remotesResolved = swaggerObj.definitionRemotesResolved;
 
       if (_.isEmpty(result.errors))
         result.errors = null;


### PR DESCRIPTION
These minor changes are necessary for the APIs.guru openapi-directory update scripts to function correctly.

They allow passing `jsonRefs` arguments down through Sway (in my use-case to parse Yaml in JSON compatible mode so duplicate properties do not throw exceptions) and the passing back of an additional copy of the validated definition with remote references resolved (as relative references would break for users downloading the definitions from APIs.guru).

Tests pass.