### PR TITLE
openapi3_to_swagger2; fix fixRef function

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -30,7 +30,7 @@ module.exports = function convert(data) {
 function fixRef(ref) {
   return ref
       .replace('#/components/schemas/', '#/definitions/')
-      .replace('#/components/', '#/x-components')
+      .replace('#/components/', '#/x-components/')
 }
 
 function fixRefs(obj) {


### PR DESCRIPTION
Missing trailing `/` character.