### PR TITLE
Update engine to be permissive

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "api-spec-converter",
   "version": "2.7.0",
   "engines": {
-    "node": "^6.0.0"
+    "node": ">=6.0.0"
   },
   "description": "Convert API descriptions between popular formats such as OpenAPI(fka Swagger), RAML, API Blueprint, WADL, etc.",
   "main": "index.js",


### PR DESCRIPTION
Getting errors w/yarn when using this package because we're on a later version of Node. This package seems to work fine with 8.9.4 -- is there a reason this was pegged at Node v6?