### PR TITLE
Fix up OpenAPI 3.0 -> Swagger 2.0 conversion

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -150,6 +150,11 @@ function convertParameters(openApiSpec, operation) {
         if (param.in !== 'body') {
             copyArrayProperties(param);
             delete param.schema;
+            delete param.allowReserved;
+            if (param.example) {
+                param['x-example'] = param.example;
+            }
+            delete param.example;
         }
     });
 }
@@ -210,6 +215,12 @@ function convertSecurityDefinitions(openApiSpec) {
         var security = openApiSpec.securityDefinitions[secKey];
         if (security.type === 'http' && security.scheme === 'basic') {
             security.type = 'basic';
+        } else if (security.type === 'http' && security.scheme === 'bearer') {
+            security.type = 'apiKey';
+            security.name = 'Authorization';
+            security.in = 'header';
+            delete security.scheme;
+            delete security.bearerFormat;
         } else if (security.type === 'oauth2') {
             var flowName = Object.keys(security.flows)[0],
                 flow = security.flows[flowName];


### PR DESCRIPTION
Fixed a number of issues that were preventing my doc from being validated:
- Handle HTTP Bearer authentication
- Rename parameter `example` to `x-example`
- Remove `allowReserved` param property

Tests pass.