### PR TITLE
Fixes: #158. Convert response headers from openapi3 to swagger2.

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -178,7 +178,7 @@ function copyArrayProperties(obj) {
 }
 
 function convertResponses(openApiSpec, operation) {
-    var code, content, contentType, response, resolved;
+    var code, content, contentType, response, resolved, headers;
     for (code in operation.responses) {
         content = false;
         contentType = 'application/json';
@@ -205,6 +205,22 @@ function convertResponses(openApiSpec, operation) {
             }
             copySchemaProperties(response);
         }
+
+        headers = response.headers;
+        if (headers) {
+            for (var header in headers) {
+                // Always resolve headers when converting to v2.
+                resolved = resolveReference(openApiSpec, headers[header])
+                // Headers should be converted like parameters.
+                if (resolved.schema){
+                    resolved.type = resolved.schema.type
+                    resolved.format = resolved.schema.format
+                    delete resolved.schema
+                }
+                headers[header] = resolved;
+            }
+        }
+
         delete response.content;
     }
 }

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -1,5 +1,28 @@
 {
   "components": {
+    "headers": {
+      "X-RateLimit-Limit": {
+        "description": "The number of allowed requests in the current period",
+        "schema": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "X-RateLimit-Remaining": {
+        "description": "The number of remaining requests in the current period",
+        "schema": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "X-RateLimit-Reset": {
+        "description": "The number of seconds left in the current period",
+        "schema": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
     "requestBodies": {
       "UserArray": {
         "content": {
@@ -1048,7 +1071,25 @@
         },
         "responses": {
           "200": {
-            "description": "No response was specified"
+            "description": "No response was specified",
+            "headers": {
+              "Retry-After": {
+                "description": "Retry contacting the endpoint *at least* after seconds.",
+                "schema": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              }
+            }
           },
           "400": {
             "description": "Invalid username supplied"

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -915,7 +915,29 @@
         ],
         "responses": {
           "200": {
-            "description": "No response was specified"
+            "description": "No response was specified",
+            "headers": {
+              "Retry-After": {
+                "description": "Retry contacting the endpoint *at least* after seconds.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "description": "The number of allowed requests in the current period",
+                "format": "int32",
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "description": "The number of remaining requests in the current period",
+                "format": "int32",
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "description": "The number of seconds left in the current period",
+                "format": "int32",
+                "type": "integer"
+              }
+            }
           },
           "400": {
             "description": "Invalid username supplied"
@@ -983,6 +1005,23 @@
     }
   ],
   "x-components": {
+    "headers": {
+      "X-RateLimit-Limit": {
+        "description": "The number of allowed requests in the current period",
+        "format": "int32",
+        "type": "integer"
+      },
+      "X-RateLimit-Remaining": {
+        "description": "The number of remaining requests in the current period",
+        "format": "int32",
+        "type": "integer"
+      },
+      "X-RateLimit-Reset": {
+        "description": "The number of seconds left in the current period",
+        "format": "int32",
+        "type": "integer"
+      }
+    },
     "requestBodies": {
       "UserArray": {
         "description": "List of user object",


### PR DESCRIPTION
Process responses and:

  - resolve headers references as they are not supported in swagger2
  - convert headers from openapi3 to swagger2