### PR TITLE
Avoid ignoring 'example' field of schema when its value is falsy like '' or 0

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'],
-    SCHEMA_PROPERTIES = ['format', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'minLength', 'maxLength', 'multipleOf', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'additionalProperties', 'pattern', 'enum', 'default'],
+    SCHEMA_PROPERTIES = ['format', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'minLength', 'maxLength', 'multipleOf', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'additionalProperties', 'pattern', 'enum', 'default', 'example'],
     ARRAY_PROPERTIES = ['type', 'items'];
 
 var APPLICATION_JSON_REGEX = /^(application\/json|[^;\/ \t]+\/[^;\/ \t]+[+]json)[ \t]*(;.*)?$/;
@@ -172,7 +172,7 @@ Converter.prototype.convertParameters = function(operation) {
             this.copySchemaProperties(param, ARRAY_PROPERTIES);
             delete param.schema;
             delete param.allowReserved;
-            if (param.example) {
+            if ('example' in param) {
                 param['x-example'] = param.example;
             }
             delete param.example;


### PR DESCRIPTION
In OpenAPI 3.0 to Swagger 2.0 conversion, 
when there's a schema like below,
```yaml
schemas:
  ID:
    type: integer
    example: 0
```

and when I referred this schema like `$ref: "#/components/schemas/ID"`,
I think `x-example: 0` should appear in the output but it doesn't.

I fixed this behavior in this PR.