### PR TITLE
A few fixes for OAS3 to Swagger2

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -30,11 +30,12 @@ Converter.prototype.convert = function() {
   this.convertInfos();
   this.convertOperations();
   if (this.spec.components) {
+    this.convertSchemas();
     this.convertSecurityDefinitions();
-    this.spec.definitions = this.spec.components.schemas;
-    delete this.spec.components.schemas;
+
     this.spec['x-components'] = this.spec.components;
     delete this.spec.components;
+
     fixRefs(this.spec);
   }
   return this.spec;
@@ -184,8 +185,15 @@ Converter.prototype.copySchemaProperties = function(obj, props) {
     let schema = this.resolveReference(this.spec, obj.schema);
     if (!schema) return;
     props.forEach(function(prop) {
-        if (schema[prop] !== undefined) {
-            obj[prop] = schema[prop];
+        var value = schema[prop];
+
+        switch (prop) {
+            case 'additionalProperties':
+                if (typeof value === 'boolean') return;
+        }
+
+        if (value !== undefined) {
+            obj[prop] = value;
         }
     });
 }
@@ -216,7 +224,6 @@ Converter.prototype.convertResponses = function(operation) {
                 response.examples = {};
                 response.examples[contentType] = content.example;
             }
-            this.copySchemaProperties(response, SCHEMA_PROPERTIES);
         }
 
         headers = response.headers;
@@ -235,6 +242,18 @@ Converter.prototype.convertResponses = function(operation) {
         }
 
         delete response.content;
+    }
+}
+
+Converter.prototype.convertSchemas = function() {
+    this.spec.definitions = this.spec.components.schemas;
+    delete this.spec.components.schemas;
+
+    for (var defName in this.spec.definitions) {
+        var def = this.spec.definitions[defName];
+        if (def.oneOf) {
+            delete def.oneOf;
+        }
     }
 }
 


### PR DESCRIPTION
- Remove `additionalProperties` on schemas if it's a boolean, as those aren't supported
- Stop copying schema properties onto base response objects (I don't think that makes sense - https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responseObject)
- Remove `oneOf` types - those aren't supported in Swagger 2.0, so this will effectively make those types `any` (not great but I don't see a better solution if the language doesn't support it)