### PR TITLE
issue #172: include OpenAPI 3.0.1 element for --order openapi

### DIFF
--- a/lib/base_format.js
+++ b/lib/base_format.js
@@ -28,14 +28,17 @@ let attr = [
   'responses',
   'parameters',
   'definitions',
+  'components',
   'paths',
   'produces',
   'consumes',
   'schemes',
   'basePath',
   'host',
+  'servers',
   'info',
   'swagger',
+  'openapi',
 ];
 
 BaseFormat.prototype.stringify = function(options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-spec-converter",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,8 +15,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
@@ -30,7 +30,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -46,8 +46,8 @@
       "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
-        "xtend": "4.0.1"
+        "acorn": "^5.4.1",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -77,8 +77,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
       },
       "dependencies": {
         "semver": {
@@ -94,10 +94,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "amqplib": {
@@ -107,11 +107,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bitsyntax": "0.0.4",
-        "bluebird": "3.5.1",
+        "bitsyntax": "~0.0.4",
+        "bluebird": "^3.4.6",
         "buffer-more-ints": "0.0.2",
-        "readable-stream": "1.1.14",
-        "safe-buffer": "5.1.1"
+        "readable-stream": "1.x >=1.1.9",
+        "safe-buffer": "^5.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -128,10 +128,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -160,8 +160,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "apib-include-directive": {
@@ -174,12 +174,12 @@
       "resolved": "https://registry.npmjs.org/apib2swagger/-/apib2swagger-1.0.0.tgz",
       "integrity": "sha1-zJjvbrd3RunNi5oi2cEDS7PV830=",
       "requires": {
-        "apib-include-directive": "0.1.0",
-        "drafter.js": "2.6.7",
-        "generate-schema": "2.6.0",
-        "js-yaml": "3.11.0",
-        "nopt": "3.0.6",
-        "uritemplate": "0.3.4"
+        "apib-include-directive": "^0.1.0",
+        "drafter.js": "^2.6.2",
+        "generate-schema": "^2.5.0",
+        "js-yaml": "^3.9.1",
+        "nopt": "^3.0.6",
+        "uritemplate": "^0.3.4"
       }
     },
     "argparse": {
@@ -187,7 +187,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -196,7 +196,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -252,9 +252,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -290,7 +290,7 @@
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       }
     },
     "async": {
@@ -300,7 +300,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -357,7 +357,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9"
+            "debug": "^2.2.0"
           }
         }
       }
@@ -368,9 +368,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -379,25 +379,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "debug": {
@@ -423,14 +423,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -453,9 +453,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -464,10 +464,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -476,10 +476,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -488,9 +488,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -499,11 +499,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -512,8 +512,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -522,8 +522,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -532,8 +532,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -542,9 +542,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -553,11 +553,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -566,12 +566,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -580,8 +580,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -590,7 +590,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -599,7 +599,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -626,9 +626,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -637,7 +637,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -646,7 +646,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -655,11 +655,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -668,15 +668,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -685,8 +685,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -695,7 +695,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -704,8 +704,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -714,7 +714,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -723,9 +723,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -734,7 +734,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -743,9 +743,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -754,10 +754,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -766,9 +766,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -777,9 +777,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -788,8 +788,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -798,12 +798,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -812,8 +812,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -822,7 +822,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -831,9 +831,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -842,7 +842,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -851,7 +851,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -860,9 +860,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -871,9 +871,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -882,7 +882,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -891,8 +891,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -901,9 +901,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       }
     },
     "babel-preset-env": {
@@ -912,36 +912,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.3",
-        "semver": "5.5.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-es2015": {
@@ -950,30 +950,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-register": {
@@ -982,13 +982,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -997,8 +997,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1015,11 +1015,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1028,15 +1028,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.3",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "debug": {
@@ -1056,10 +1056,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babelify": {
@@ -1068,8 +1068,8 @@
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "object-assign": "4.1.1"
+        "babel-core": "^6.0.14",
+        "object-assign": "^4.0.0"
       }
     },
     "babylon": {
@@ -1114,7 +1114,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -1149,7 +1149,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "~2.0.5"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -1166,12 +1166,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1207,15 +1207,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -1234,7 +1234,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -1243,7 +1243,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1253,9 +1253,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -1270,12 +1270,12 @@
       "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "combine-source-map": "0.8.0",
-        "defined": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "through2": "2.0.3",
-        "umd": "3.0.1"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
       }
     },
     "browser-resolve": {
@@ -1301,53 +1301,53 @@
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "assert": "1.4.1",
-        "browser-pack": "6.0.4",
-        "browser-resolve": "1.11.2",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.1.4",
-        "events": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "htmlescape": "1.1.1",
-        "https-browserify": "0.0.1",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.0.1",
-        "labeled-stream-splicer": "2.0.0",
-        "module-deps": "4.1.1",
-        "os-browserify": "0.1.2",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.4",
-        "resolve": "1.5.0",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "0.10.31",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "2.0.3",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.1",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^4.1.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.1.2",
+        "events": "~1.1.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "labeled-stream-splicer": "^2.0.0",
+        "module-deps": "^4.0.8",
+        "os-browserify": "~0.1.1",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^2.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "string_decoder": {
@@ -1364,12 +1364,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1378,9 +1378,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1389,9 +1389,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -1400,8 +1400,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -1410,13 +1410,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1425,7 +1425,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "browserslist": {
@@ -1434,8 +1434,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000810",
-        "electron-to-chromium": "1.3.34"
+        "caniuse-lite": "^1.0.30000792",
+        "electron-to-chromium": "^1.3.30"
       }
     },
     "buffer": {
@@ -1444,9 +1444,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-more-ints": {
@@ -1533,9 +1533,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       }
     },
     "chai-as-promised": {
@@ -1568,11 +1568,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chance": {
@@ -1586,15 +1586,921 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "1.1.3",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/fsevents/-/fsevents-1.1.3.tgz",
+          "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.3.0",
+            "node-pre-gyp": "^0.6.39"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true,
+              "dev": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "^0.14.3"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "~2.0.0"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hoek": "2.x.x"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^0.4.1",
+                "concat-map": "0.0.1"
+              }
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "boom": "2.x.x"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "^1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "~0.1.0"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "^1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true,
+              "dev": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true,
+              "dev": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "~0.1.0"
+              }
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "jsonify": "~0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "bundled": true,
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mime-db": "~1.27.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.39",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "hawk": "3.1.3",
+                "mkdirp": "^0.5.1",
+                "nopt": "^4.0.1",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "request": "2.81.0",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^2.2.1",
+                "tar-pack": "^3.4.0"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true,
+              "dev": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-shims": "~1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hoek": "2.x.x"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jodid25519": "^1.0.0",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "fstream": "^1.0.10",
+                "fstream-ignore": "^1.0.5",
+                "once": "^1.3.3",
+                "readable-stream": "^2.1.4",
+                "rimraf": "^2.5.1",
+                "tar": "^2.2.1",
+                "uid-number": "^0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "punycode": "^1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "1.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "extsprintf": "1.0.2"
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
       }
     },
     "cipher-base": {
@@ -1603,8 +2509,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -1623,9 +2529,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "string-width": {
@@ -1633,9 +2539,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -1656,7 +2562,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1676,7 +2582,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.5.0"
       }
     },
     "combine-source-map": {
@@ -1685,10 +2591,10 @@
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.6.2",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.5.7"
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
       },
       "dependencies": {
         "convert-source-map": {
@@ -1710,7 +2616,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1757,9 +2663,9 @@
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.0.6",
-        "typedarray": "0.0.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "~2.0.0",
+        "typedarray": "~0.0.5"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -1774,12 +2680,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1798,7 +2704,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -1819,7 +2725,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -1868,8 +2774,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -1878,10 +2784,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1890,12 +2796,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -1903,9 +2809,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -1913,7 +2819,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1921,7 +2827,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -1932,17 +2838,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "custom-event": {
@@ -1956,7 +2862,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -2025,7 +2931,7 @@
       "resolved": "https://registry.npmjs.org/deep-sort-object/-/deep-sort-object-1.0.2.tgz",
       "integrity": "sha1-OJLc7139Dvwtb6lr6rzLM82O+R8=",
       "requires": {
-        "is-plain-object": "2.0.4"
+        "is-plain-object": "^2.0.1"
       }
     },
     "defined": {
@@ -2041,9 +2947,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ast-types": "0.11.3",
-        "escodegen": "1.9.1",
-        "esprima": "3.1.3"
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
       },
       "dependencies": {
         "escodegen": {
@@ -2053,11 +2959,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.6.1"
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
           }
         },
         "esprima": {
@@ -2099,10 +3005,10 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "2.0.3"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "deref": {
@@ -2110,7 +3016,7 @@
       "resolved": "https://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
       "integrity": "sha1-vVqW1F2+0wEbuBvfaN31S+jhvU4=",
       "requires": {
-        "deep-extend": "0.4.2"
+        "deep-extend": "^0.4.0"
       }
     },
     "des.js": {
@@ -2119,8 +3025,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detect-indent": {
@@ -2129,7 +3035,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detective": {
@@ -2138,8 +3044,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -2168,9 +3074,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dom-serialize": {
@@ -2179,10 +3085,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "1.0.1",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "void-elements": "2.0.1"
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -2214,7 +3120,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "^2.0.2"
       }
     },
     "duplexify": {
@@ -2222,10 +3128,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ebnf-parser": {
@@ -2239,7 +3145,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -2260,13 +3166,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encodeurl": {
@@ -2280,7 +3186,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -2288,7 +3194,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -2297,13 +3203,13 @@
       "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "uws": "9.14.0",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "uws": "~9.14.0",
+        "ws": "~3.3.1"
       }
     },
     "engine.io-client": {
@@ -2314,14 +3220,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       }
     },
@@ -2332,10 +3238,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.2"
+        "has-binary2": "~1.0.2"
       }
     },
     "ent": {
@@ -2349,7 +3255,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es6-promise": {
@@ -2363,7 +3269,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -2383,9 +3289,9 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
       "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
       "requires": {
-        "esprima": "1.0.4",
-        "estraverse": "0.0.4",
-        "source-map": "0.6.0"
+        "esprima": "~1.0.2",
+        "estraverse": "~0.0.4",
+        "source-map": ">= 0.1.2"
       },
       "dependencies": {
         "esprima": {
@@ -2429,8 +3335,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -2438,13 +3344,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-braces": {
@@ -2453,9 +3359,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "0.2.3",
-        "array-unique": "0.2.1",
-        "braces": "0.1.5"
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
       },
       "dependencies": {
         "braces": {
@@ -2464,7 +3370,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "0.1.1"
+            "expand-range": "^0.1.0"
           }
         },
         "expand-range": {
@@ -2473,8 +3379,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "0.1.1",
-            "repeat-string": "0.2.2"
+            "is-number": "^0.1.1",
+            "repeat-string": "^0.2.2"
           }
         },
         "is-number": {
@@ -2497,7 +3403,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2506,7 +3412,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "extend": {
@@ -2520,7 +3426,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -2541,9 +3447,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.4",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "debug": {
@@ -2599,7 +3505,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "file-uri-to-path": {
@@ -2621,11 +3527,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "isobject": {
@@ -2646,12 +3552,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2676,7 +3582,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "follow-redirects": {
@@ -2685,7 +3591,7 @@
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       }
     },
     "for-in": {
@@ -2700,7 +3606,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -2713,9 +3619,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "format-util": {
@@ -2729,7 +3635,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "formidable": {
@@ -2743,7 +3649,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "1.0.0"
+        "null-check": "^1.0.0"
       }
     },
     "fs-extra": {
@@ -2752,9 +3658,9 @@
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
       }
     },
     "fs.realpath": {
@@ -2764,906 +3670,416 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
-      "optional": true,
+      "version": "1.2.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "requires": {
-        "nan": "2.9.2",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "version": "1.1.1",
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "1.2.0",
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "version": "1.0.0",
+          "bundled": true
         },
         "brace-expansion": {
-          "version": "1.1.7",
+          "version": "1.1.11",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
+          "bundled": true
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "0.5.1",
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "1.0.3",
+          "bundled": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
-        "hawk": {
-          "version": "3.1.3",
+        "iconv-lite": {
+          "version": "0.4.21",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "safer-buffer": "^2.1.0"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "1.3.5",
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
           "bundled": true,
-          "dev": true
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
         },
         "node-pre-gyp": {
-          "version": "0.6.39",
+          "version": "0.10.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
-          "version": "4.1.0",
+          "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "2.0.0",
+          "bundled": true
         },
         "rc": {
-          "version": "1.2.1",
+          "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.3.6",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
         },
         "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "5.5.0",
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
+          "bundled": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "~5.1.0"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
-          "version": "2.2.1",
+          "version": "4.4.1",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
         }
       }
     },
@@ -3674,7 +4090,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "xregexp": "2.0.0"
       },
       "dependencies": {
@@ -3692,10 +4108,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3727,7 +4143,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "generate-schema": {
@@ -3735,8 +4151,8 @@
       "resolved": "https://registry.npmjs.org/generate-schema/-/generate-schema-2.6.0.tgz",
       "integrity": "sha512-EUBKfJNzT8f91xUk5X5gKtnbdejZeE065UAJ3BCzE8VEbvwKI9Pm5jaWmqVeK1MYc1g5weAVFDTSJzN7ymtTqA==",
       "requires": {
-        "commander": "2.15.1",
-        "type-of-is": "3.5.1"
+        "commander": "^2.9.0",
+        "type-of-is": "^3.4.0"
       }
     },
     "get-caller-file": {
@@ -3756,12 +4172,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "data-uri-to-buffer": "1.2.0",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "file-uri-to-path": "1.0.0",
-        "ftp": "0.3.10",
-        "readable-stream": "2.3.4"
+        "data-uri-to-buffer": "1",
+        "debug": "2",
+        "extend": "3",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "2"
       },
       "dependencies": {
         "debug": {
@@ -3781,7 +4197,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -3790,12 +4206,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3804,8 +4220,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -3814,7 +4230,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -3828,13 +4244,13 @@
       "resolved": "https://registry.npmjs.org/google-discovery-to-swagger/-/google-discovery-to-swagger-2.0.0.tgz",
       "integrity": "sha1-L52qedOx4rJlFopjK3eMsjrwpoo=",
       "requires": {
-        "json-schema-compatibility": "1.1.0",
-        "jsonpath": "0.2.12",
-        "lodash": "4.17.10",
-        "mime-db": "1.33.0",
-        "mime-lookup": "0.0.2",
-        "traverse": "0.6.6",
-        "urijs": "1.19.1"
+        "json-schema-compatibility": "^1.1.0",
+        "jsonpath": "^0.2.2",
+        "lodash": "^4.1.0",
+        "mime-db": "^1.21.0",
+        "mime-lookup": "^0.0.2",
+        "traverse": "~0.6.6",
+        "urijs": "^1.17.0"
       }
     },
     "got": {
@@ -3842,15 +4258,15 @@
       "resolved": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
       "integrity": "sha1-5Ah6LNWbXSDy0WnchdIWntnon1Y=",
       "requires": {
-        "duplexify": "3.5.3",
-        "infinity-agent": "1.0.2",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "object-assign": "2.1.1",
-        "prepend-http": "1.0.4",
-        "read-all-stream": "1.0.2",
-        "statuses": "1.4.0",
-        "timed-out": "2.0.0"
+        "duplexify": "^3.2.0",
+        "infinity-agent": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "prepend-http": "^1.0.0",
+        "read-all-stream": "^1.0.0",
+        "statuses": "^1.2.1",
+        "timed-out": "^2.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -3870,7 +4286,7 @@
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
       "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.11.1"
       }
     },
     "growl": {
@@ -3889,8 +4305,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -3899,7 +4315,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -3908,7 +4324,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -3946,7 +4362,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -3955,8 +4371,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hasha": {
@@ -3965,8 +4381,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -3974,10 +4390,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hipchat-notifier": {
@@ -3987,8 +4403,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "4.17.10",
-        "request": "2.85.0"
+        "lodash": "^4.0.0",
+        "request": "^2.0.0"
       }
     },
     "hmac-drbg": {
@@ -3997,9 +4413,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -4013,8 +4429,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -4034,10 +4450,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-proxy": {
@@ -4046,9 +4462,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "3.1.0",
-        "follow-redirects": "1.4.1",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-agent": {
@@ -4057,9 +4473,9 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
       },
       "dependencies": {
         "debug": {
@@ -4078,9 +4494,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "http-status-codes": {
@@ -4094,8 +4510,8 @@
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
       "requires": {
-        "httpreq": "0.4.24",
-        "underscore": "1.7.0"
+        "httpreq": ">=0.4.22",
+        "underscore": "~1.7.0"
       }
     },
     "httpreq": {
@@ -4116,9 +4532,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
       },
       "dependencies": {
         "debug": {
@@ -4167,8 +4583,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4182,7 +4598,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "~0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -4199,14 +4615,14 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "combine-source-map": "0.7.2",
-        "concat-stream": "1.5.2",
-        "is-buffer": "1.1.6",
-        "lexical-scope": "1.2.0",
-        "process": "0.11.10",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.7.1",
+        "concat-stream": "~1.5.1",
+        "is-buffer": "^1.1.0",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "combine-source-map": {
@@ -4215,10 +4631,10 @@
           "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.6.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.5.3"
           }
         },
         "convert-source-map": {
@@ -4241,7 +4657,7 @@
       "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -4267,7 +4683,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -4281,7 +4697,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-dotfile": {
@@ -4296,7 +4712,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4317,7 +4733,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4325,7 +4741,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -4334,7 +4750,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
@@ -4351,11 +4767,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -4364,7 +4780,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-plain-object": {
@@ -4372,7 +4788,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -4465,12 +4881,12 @@
       "integrity": "sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=",
       "requires": {
         "JSONSelect": "0.4.0",
-        "cjson": "0.2.1",
-        "ebnf-parser": "0.1.10",
+        "cjson": "~0.2.1",
+        "ebnf-parser": "~0.1.9",
         "escodegen": "0.0.21",
-        "esprima": "1.0.4",
-        "jison-lex": "0.2.1",
-        "lex-parser": "0.1.4",
+        "esprima": "1.0.x",
+        "jison-lex": "0.2.x",
+        "lex-parser": "~0.1.3",
         "nomnom": "1.5.2"
       },
       "dependencies": {
@@ -4486,7 +4902,7 @@
       "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
       "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4=",
       "requires": {
-        "lex-parser": "0.1.4",
+        "lex-parser": "0.1.x",
         "nomnom": "1.5.2"
       }
     },
@@ -4511,8 +4927,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4532,13 +4948,13 @@
       "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
       "integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
       "requires": {
-        "commander": "2.15.1",
-        "graphlib": "2.1.5",
-        "js-yaml": "3.11.0",
-        "native-promise-only": "0.8.1",
-        "path-loader": "1.0.4",
-        "slash": "1.0.0",
-        "uri-js": "3.0.2"
+        "commander": "^2.9.0",
+        "graphlib": "^2.1.1",
+        "js-yaml": "^3.8.3",
+        "native-promise-only": "^0.8.1",
+        "path-loader": "^1.0.2",
+        "slash": "^1.0.0",
+        "uri-js": "^3.0.2"
       }
     },
     "json-schema": {
@@ -4556,10 +4972,10 @@
       "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.2.8.tgz",
       "integrity": "sha1-rGmxuzaCiPfw/IxzB57jP8TCQL0=",
       "requires": {
-        "chance": "0.8.0",
-        "deref": "0.6.4",
-        "faker": "3.1.0",
-        "randexp": "0.4.9"
+        "chance": "^0.8.0",
+        "deref": "^0.6.3",
+        "faker": "^3.0.1",
+        "randexp": "^0.4.2"
       }
     },
     "json-schema-ref-parser": {
@@ -4567,12 +4983,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.3.1.tgz",
       "integrity": "sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ==",
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "debug": "3.1.0",
-        "es6-promise": "4.2.4",
-        "js-yaml": "3.11.0",
-        "ono": "4.0.3",
-        "z-schema": "3.19.1"
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.0.0",
+        "es6-promise": "^4.1.1",
+        "js-yaml": "^3.9.1",
+        "ono": "^4.0.2",
+        "z-schema": "^3.18.2"
       }
     },
     "json-schema-traverse": {
@@ -4586,7 +5002,7 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4606,7 +5022,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -4663,31 +5079,31 @@
       "integrity": "sha1-TS25QChQpmVR+nhLAWT7CCTtjEs=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "body-parser": "1.18.2",
-        "chokidar": "1.7.0",
-        "colors": "1.2.3",
-        "combine-lists": "1.0.1",
-        "connect": "3.6.6",
-        "core-js": "2.5.3",
-        "di": "0.0.1",
-        "dom-serialize": "2.2.1",
-        "expand-braces": "0.1.2",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "http-proxy": "1.17.0",
-        "isbinaryfile": "3.0.2",
-        "lodash": "4.17.10",
-        "log4js": "2.5.3",
-        "mime": "1.6.0",
-        "minimatch": "3.0.4",
-        "optimist": "0.6.1",
-        "qjobs": "1.2.0",
-        "range-parser": "1.2.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
+        "bluebird": "^3.3.0",
+        "body-parser": "^1.16.1",
+        "chokidar": "^1.4.1",
+        "colors": "^1.1.0",
+        "combine-lists": "^1.0.0",
+        "connect": "^3.6.0",
+        "core-js": "^2.2.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^4.17.4",
+        "log4js": "^2.3.9",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.2",
+        "optimist": "^0.6.1",
+        "qjobs": "^1.1.4",
+        "range-parser": "^1.2.0",
+        "rimraf": "^2.6.0",
+        "safe-buffer": "^5.0.1",
         "socket.io": "2.0.4",
-        "source-map": "0.6.1",
+        "source-map": "^0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.2.1"
       },
@@ -4712,13 +5128,13 @@
       "integrity": "sha1-XgvEQ6taYOvkbxcJXgnHXK8MML4=",
       "dev": true,
       "requires": {
-        "chai": "3.5.0",
-        "chai-as-promised": "5.3.0",
-        "chai-dom": "1.7.0",
-        "chai-jquery": "2.0.0",
-        "chai-things": "0.2.0",
-        "sinon": "1.17.7",
-        "sinon-chai": "2.14.0"
+        "chai": "^3.4.1",
+        "chai-as-promised": "^5.1.0",
+        "chai-dom": "^1.2.2",
+        "chai-jquery": "^2.0.0",
+        "chai-things": "^0.2.0",
+        "sinon": "^1.17.2",
+        "sinon-chai": "^2.8.0"
       }
     },
     "karma-chrome-launcher": {
@@ -4727,8 +5143,8 @@
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
-        "fs-access": "1.0.1",
-        "which": "1.3.0"
+        "fs-access": "^1.0.0",
+        "which": "^1.2.1"
       }
     },
     "karma-mocha": {
@@ -4754,9 +5170,9 @@
       "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.1",
-        "log-symbols": "2.2.0",
-        "strip-ansi": "4.0.0"
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4771,7 +5187,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4780,9 +5196,9 @@
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.2.0"
           }
         },
         "strip-ansi": {
@@ -4791,7 +5207,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4800,7 +5216,7 @@
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4811,8 +5227,8 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
-        "phantomjs-prebuilt": "2.1.16"
+        "lodash": "^4.0.1",
+        "phantomjs-prebuilt": "^2.1.7"
       }
     },
     "kew": {
@@ -4827,7 +5243,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -4836,7 +5252,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "labeled-stream-splicer": {
@@ -4845,9 +5261,9 @@
       "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "stream-splicer": "2.0.0"
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -4863,7 +5279,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -4873,8 +5289,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lex-parser": {
@@ -4888,7 +5304,7 @@
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true,
       "requires": {
-        "astw": "2.2.0"
+        "astw": "^2.0.0"
       }
     },
     "libbase64": {
@@ -4927,10 +5343,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -4938,8 +5354,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -4969,7 +5385,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.1"
+        "chalk": "^2.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4978,7 +5394,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4987,9 +5403,9 @@
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.2.0"
           }
         },
         "supports-color": {
@@ -4998,7 +5414,7 @@
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5009,19 +5425,19 @@
       "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
       "dev": true,
       "requires": {
-        "amqplib": "0.5.2",
-        "axios": "0.15.3",
-        "circular-json": "0.5.3",
-        "date-format": "1.2.0",
-        "debug": "3.1.0",
-        "hipchat-notifier": "1.1.0",
-        "loggly": "1.1.1",
-        "mailgun-js": "0.7.15",
-        "nodemailer": "2.7.2",
-        "redis": "2.8.0",
-        "semver": "5.5.0",
-        "slack-node": "0.2.0",
-        "streamroller": "0.7.0"
+        "amqplib": "^0.5.2",
+        "axios": "^0.15.3",
+        "circular-json": "^0.5.1",
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "hipchat-notifier": "^1.1.0",
+        "loggly": "^1.1.0",
+        "mailgun-js": "^0.7.0",
+        "nodemailer": "^2.5.0",
+        "redis": "^2.7.1",
+        "semver": "^5.3.0",
+        "slack-node": "~0.2.0",
+        "streamroller": "^0.7.0"
       }
     },
     "loggly": {
@@ -5031,9 +5447,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "json-stringify-safe": "5.0.1",
-        "request": "2.75.0",
-        "timespan": "2.3.0"
+        "json-stringify-safe": "5.0.x",
+        "request": "2.75.x",
+        "timespan": "2.3.x"
       },
       "dependencies": {
         "assert-plus": {
@@ -5056,7 +5472,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -5073,7 +5489,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -5083,9 +5499,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
           }
         },
         "har-validator": {
@@ -5095,10 +5511,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.15.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -5108,10 +5524,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -5127,9 +5543,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "node-uuid": {
@@ -5153,27 +5569,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.7.0",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.0.0",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.3",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.0.0",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1"
           }
         },
         "sntp": {
@@ -5183,7 +5599,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "tunnel-agent": {
@@ -5207,7 +5623,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -5220,8 +5636,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "mailcomposer": {
@@ -5242,15 +5658,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "2.1.5",
-        "debug": "2.2.0",
-        "form-data": "2.1.4",
-        "inflection": "1.10.0",
-        "is-stream": "1.1.0",
-        "path-proxy": "1.0.0",
-        "proxy-agent": "2.0.0",
-        "q": "1.4.1",
-        "tsscmp": "1.0.5"
+        "async": "~2.1.2",
+        "debug": "~2.2.0",
+        "form-data": "~2.1.1",
+        "inflection": "~1.10.0",
+        "is-stream": "^1.1.0",
+        "path-proxy": "~1.0.0",
+        "proxy-agent": "~2.0.0",
+        "q": "~1.4.0",
+        "tsscmp": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -5270,9 +5686,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "ms": {
@@ -5297,8 +5713,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -5307,8 +5723,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -5324,7 +5740,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "methods": {
@@ -5338,19 +5754,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -5359,8 +5775,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -5383,7 +5799,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -5409,7 +5825,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5472,8 +5888,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "lru-cache": {
@@ -5488,8 +5904,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "ms": {
@@ -5512,21 +5928,21 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "browser-resolve": "1.11.2",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "defined": "1.0.0",
-        "detective": "4.7.1",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.4",
-        "resolve": "1.5.0",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.0",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "ms": {
@@ -5535,11 +5951,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
-      "dev": true,
-      "optional": true
+      "version": "2.10.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -5564,8 +5978,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-readfiles": {
@@ -5573,7 +5987,7 @@
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
       "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
       "requires": {
-        "es6-promise": "3.3.1"
+        "es6-promise": "^3.2.1"
       },
       "dependencies": {
         "es6-promise": {
@@ -5613,8 +6027,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "1.1.15"
+            "ip": "^1.1.2",
+            "smart-buffer": "^1.0.4"
           }
         }
       }
@@ -5680,8 +6094,8 @@
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
       "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.1.7"
+        "colors": "0.5.x",
+        "underscore": "1.1.x"
       },
       "dependencies": {
         "underscore": {
@@ -5696,7 +6110,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -5704,10 +6118,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -5716,7 +6130,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -5724,7 +6138,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "null-check": {
@@ -5760,8 +6174,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -5778,7 +6192,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "ono": {
@@ -5786,7 +6200,7 @@
       "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.3.tgz",
       "integrity": "sha512-7QIxG4UB00H7CR7fhXC/U7VhB5DK9wsYLwaYBui1JmQoXtLkhIBn3fbuk6FgAP+ctWeBsWVTM+R/bThvUZN+ww==",
       "requires": {
-        "format-util": "1.0.3"
+        "format-util": "^1.0.3"
       }
     },
     "optimist": {
@@ -5795,8 +6209,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -5814,12 +6228,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-browserify": {
@@ -5839,9 +6253,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -5860,7 +6274,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -5868,7 +6282,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -5883,15 +6297,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "get-uri": "2.0.1",
-        "http-proxy-agent": "1.0.0",
-        "https-proxy-agent": "1.0.0",
-        "pac-resolver": "2.0.0",
-        "raw-body": "2.3.2",
-        "socks-proxy-agent": "2.1.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3",
+        "get-uri": "2",
+        "http-proxy-agent": "1",
+        "https-proxy-agent": "1",
+        "pac-resolver": "~2.0.0",
+        "raw-body": "2",
+        "socks-proxy-agent": "2"
       },
       "dependencies": {
         "debug": {
@@ -5913,11 +6327,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "co": "3.0.6",
-        "degenerator": "1.0.4",
+        "co": "~3.0.6",
+        "degenerator": "~1.0.2",
         "ip": "1.0.1",
-        "netmask": "1.0.6",
-        "thunkify": "2.1.2"
+        "netmask": "~1.0.4",
+        "thunkify": "~2.1.1"
       },
       "dependencies": {
         "co": {
@@ -5941,7 +6355,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "~0.11.15"
       }
     },
     "parse-asn1": {
@@ -5950,11 +6364,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -5963,10 +6377,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -5974,7 +6388,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parseqs": {
@@ -5983,7 +6397,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -5992,7 +6406,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -6028,8 +6442,8 @@
       "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
       "integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
       "requires": {
-        "native-promise-only": "0.8.1",
-        "superagent": "3.8.2"
+        "native-promise-only": "^0.8.1",
+        "superagent": "^3.6.3"
       }
     },
     "path-parse": {
@@ -6051,7 +6465,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inflection": "1.3.8"
+        "inflection": "~1.3.0"
       },
       "dependencies": {
         "inflection": {
@@ -6083,7 +6497,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -6092,11 +6506,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -6116,15 +6530,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4",
-        "extract-zip": "1.6.6",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.85.0",
-        "request-progress": "2.0.1",
-        "which": "1.3.0"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       }
     },
     "pify": {
@@ -6144,7 +6558,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -6199,14 +6613,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "http-proxy-agent": "1.0.0",
-        "https-proxy-agent": "1.0.0",
-        "lru-cache": "2.6.5",
-        "pac-proxy-agent": "1.1.0",
-        "socks-proxy-agent": "2.1.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3",
+        "http-proxy-agent": "1",
+        "https-proxy-agent": "1",
+        "lru-cache": "~2.6.5",
+        "pac-proxy-agent": "1",
+        "socks-proxy-agent": "2"
       },
       "dependencies": {
         "debug": {
@@ -6245,11 +6659,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -6263,14 +6677,14 @@
       "integrity": "sha512-wx10aPQPpGJVxdB6yoDSLm9p4rCwARUSLMVV0bx++owuqkvviXKyiFM3EWsywaFmjOKNPXacIjplF7xhHiFP3w==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "extract-zip": "1.6.6",
-        "https-proxy-agent": "2.2.1",
-        "mime": "1.6.0",
-        "progress": "2.0.0",
-        "proxy-from-env": "1.0.0",
-        "rimraf": "2.6.2",
-        "ws": "3.3.3"
+        "debug": "^2.6.8",
+        "extract-zip": "^1.6.5",
+        "https-proxy-agent": "^2.1.0",
+        "mime": "^1.3.4",
+        "progress": "^2.0.0",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^3.0.0"
       },
       "dependencies": {
         "agent-base": {
@@ -6279,7 +6693,7 @@
           "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "debug": {
@@ -6297,8 +6711,8 @@
           "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.0",
-            "debug": "3.1.0"
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
           },
           "dependencies": {
             "debug": {
@@ -6353,13 +6767,13 @@
       "resolved": "https://registry.npmjs.org/raml-parser/-/raml-parser-0.8.18.tgz",
       "integrity": "sha1-CHM3UDT4uKHSDBDjFHtiebM0l6g=",
       "requires": {
-        "got": "2.4.0",
-        "jju": "1.2.1",
-        "json-schema-ref-parser": "3.3.1",
-        "object-assign": "4.1.1",
-        "pluralize": "1.1.6",
+        "got": "~2.4.0",
+        "jju": "~1.2.0",
+        "json-schema-ref-parser": "^3.1.2",
+        "object-assign": "^4.1.0",
+        "pluralize": "~1.1.1",
         "q": "0.9.7",
-        "uritemplate": "0.3.4"
+        "uritemplate": "~0.3.4"
       }
     },
     "raml-to-swagger": {
@@ -6367,11 +6781,11 @@
       "resolved": "https://registry.npmjs.org/raml-to-swagger/-/raml-to-swagger-1.1.0.tgz",
       "integrity": "sha1-jVMLSN3WOE7arEvQUVJv6wXwl2Y=",
       "requires": {
-        "http-status-codes": "1.3.0",
-        "json-schema-compatibility": "1.1.0",
-        "jsonpath": "0.2.12",
-        "lodash": "4.17.10",
-        "urijs": "1.19.1"
+        "http-status-codes": "^1.0.5",
+        "json-schema-compatibility": "^1.1.0",
+        "jsonpath": "^0.2.5",
+        "lodash": "^4.1.0",
+        "urijs": "^1.17.0"
       }
     },
     "randexp": {
@@ -6379,8 +6793,8 @@
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
       "integrity": "sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
       "requires": {
-        "drange": "1.0.0",
-        "ret": "0.2.2"
+        "drange": "^1.0.0",
+        "ret": "^0.2.0"
       }
     },
     "randomatic": {
@@ -6389,8 +6803,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6399,7 +6813,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6408,7 +6822,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6419,7 +6833,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6430,7 +6844,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -6439,8 +6853,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -6476,7 +6890,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "setprototypeof": {
@@ -6498,7 +6912,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "^2.0.2"
       }
     },
     "read-pkg": {
@@ -6506,9 +6920,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -6516,8 +6930,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -6525,13 +6939,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -6540,10 +6954,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.4",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "redis": {
@@ -6553,9 +6967,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
       }
     },
     "redis-commands": {
@@ -6590,9 +7004,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -6601,7 +7015,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu-core": {
@@ -6610,9 +7024,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -6627,7 +7041,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -6654,7 +7068,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -6662,28 +7076,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-progress": {
@@ -6692,7 +7106,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "requestretry": {
@@ -6702,10 +7116,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "extend": "3.0.1",
-        "lodash": "4.17.10",
-        "request": "2.85.0",
-        "when": "3.7.8"
+        "extend": "^3.0.0",
+        "lodash": "^4.15.0",
+        "request": "^2.74.0",
+        "when": "^3.7.7"
       }
     },
     "require-directory": {
@@ -6730,7 +7144,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "ret": {
@@ -6744,7 +7158,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -6753,8 +7167,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "safe-buffer": {
@@ -6801,8 +7215,8 @@
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shasum": {
@@ -6811,8 +7225,8 @@
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.10"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shebang-command": {
@@ -6820,7 +7234,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -6834,10 +7248,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "should": {
@@ -6845,11 +7259,11 @@
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
       "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
       "requires": {
-        "should-equal": "2.0.0",
-        "should-format": "3.0.3",
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.1.0",
-        "should-util": "1.0.0"
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
       }
     },
     "should-equal": {
@@ -6857,7 +7271,7 @@
       "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "requires": {
-        "should-type": "1.4.0"
+        "should-type": "^1.4.0"
       }
     },
     "should-format": {
@@ -6865,8 +7279,8 @@
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
       "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "requires": {
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.1.0"
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
       }
     },
     "should-type": {
@@ -6879,8 +7293,8 @@
       "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
       "requires": {
-        "should-type": "1.4.0",
-        "should-util": "1.0.0"
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
       }
     },
     "should-util": {
@@ -6908,7 +7322,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.3"
+        "util": ">=0.10.3 <1"
       }
     },
     "sinon-chai": {
@@ -6924,7 +7338,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "requestretry": "1.13.0"
+        "requestretry": "^1.2.2"
       }
     },
     "slash": {
@@ -6953,7 +7367,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "socket.io": {
@@ -6962,11 +7376,11 @@
       "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "engine.io": "3.1.5",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~2.6.6",
+        "engine.io": "~3.1.0",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.0.4",
-        "socket.io-parser": "3.1.3"
+        "socket.io-parser": "~3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -6996,14 +7410,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "engine.io-client": "3.1.6",
+        "debug": "~2.6.4",
+        "engine.io-client": "~3.1.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.3",
+        "socket.io-parser": "~3.1.1",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -7025,8 +7439,8 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "has-binary2": "1.0.2",
+        "debug": "~3.1.0",
+        "has-binary2": "~1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -7044,8 +7458,8 @@
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "ip": "^1.1.4",
+        "smart-buffer": "^1.0.13"
       },
       "dependencies": {
         "ip": {
@@ -7062,9 +7476,9 @@
       "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "extend": "3.0.1",
-        "socks": "1.1.10"
+        "agent-base": "2",
+        "extend": "3",
+        "socks": "~1.1.5"
       }
     },
     "source-map": {
@@ -7078,7 +7492,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -7094,8 +7508,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7108,8 +7522,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7127,14 +7541,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-eval": {
@@ -7142,7 +7556,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.3.tgz",
       "integrity": "sha1-Aj8XrJ/uQm6niMEuo5IG3Bdfiyo=",
       "requires": {
-        "escodegen": "0.0.28"
+        "escodegen": "~0.0.24"
       },
       "dependencies": {
         "escodegen": {
@@ -7150,9 +7564,9 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
           "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
           "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.3.2",
-            "source-map": "0.6.0"
+            "esprima": "~1.0.2",
+            "estraverse": "~1.3.0",
+            "source-map": ">= 0.1.2"
           }
         },
         "esprima": {
@@ -7178,8 +7592,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner2": {
@@ -7188,8 +7602,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.4"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-http": {
@@ -7198,11 +7612,11 @@
       "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -7216,8 +7630,8 @@
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "streamroller": {
@@ -7226,10 +7640,10 @@
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "1.2.0",
-        "debug": "3.1.0",
-        "mkdirp": "0.5.1",
-        "readable-stream": "2.3.4"
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^2.3.0"
       }
     },
     "string-width": {
@@ -7237,8 +7651,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7256,7 +7670,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7266,7 +7680,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -7279,7 +7693,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -7298,7 +7712,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -7314,16 +7728,16 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.2",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.4"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       }
     },
     "supports-color": {
@@ -7337,8 +7751,8 @@
       "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-1.4.4.tgz",
       "integrity": "sha512-ylYS/Quk3L2A5zGtS5LQFMOtSKTU7Ot8pEAzlG4G/lb7+zC4FnlbD4+CKeQVf+mSGljschOjKHejvtCRyDKbsw==",
       "requires": {
-        "common-prefix": "1.1.0",
-        "urijs": "1.19.1"
+        "common-prefix": "^1.1.0",
+        "urijs": "^1.16.1"
       }
     },
     "swagger-methods": {
@@ -7356,15 +7770,15 @@
       "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-2.9.2.tgz",
       "integrity": "sha512-kav+PP5CPlcLePdTb1kYjLg+ioAnzcm1jCXybFH+3WmFah94+gq4TTT4+y3Y2CumPiPgSm20Z+h52xOkIcPRAw==",
       "requires": {
-        "ajv": "5.5.2",
-        "call-me-maybe": "1.0.1",
-        "co": "4.6.0",
-        "jgexml": "0.3.8",
-        "js-yaml": "3.11.0",
-        "node-fetch": "1.7.3",
-        "node-readfiles": "0.2.0",
-        "should": "13.2.1",
-        "yargs": "9.0.1"
+        "ajv": "^5.0.1",
+        "call-me-maybe": "^1.0.1",
+        "co": "^4.6.0",
+        "jgexml": "^0.3.8",
+        "js-yaml": "^3.6.1",
+        "node-fetch": "^1.6.3",
+        "node-readfiles": "^0.2.0",
+        "should": "^13.0.1",
+        "yargs": "^9.0.1"
       }
     },
     "sway": {
@@ -7372,17 +7786,17 @@
       "resolved": "https://registry.npmjs.org/sway/-/sway-1.0.0.tgz",
       "integrity": "sha1-No/8Dpa9hCJu0bmzPWa+V9oE8Jo=",
       "requires": {
-        "debug": "2.6.9",
-        "js-base64": "2.4.3",
-        "js-yaml": "3.11.0",
-        "json-refs": "2.1.7",
-        "json-schema-faker": "0.2.8",
-        "lodash": "4.17.10",
-        "native-promise-only": "0.8.1",
-        "path-to-regexp": "1.7.0",
-        "swagger-methods": "1.0.4",
+        "debug": "^2.2.0",
+        "js-base64": "^2.1.9",
+        "js-yaml": "^3.5.2",
+        "json-refs": "^2.1.5",
+        "json-schema-faker": "^0.2.8",
+        "lodash": "^4.2.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.2.1",
+        "swagger-methods": "^1.0.0",
         "swagger-schema-official": "2.0.0-bab6bed",
-        "z-schema": "3.19.1"
+        "z-schema": "^3.16.1"
       },
       "dependencies": {
         "debug": {
@@ -7401,7 +7815,7 @@
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.3.0"
+        "acorn-node": "^1.2.0"
       }
     },
     "throttleit": {
@@ -7422,8 +7836,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.4",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "thunkify": {
@@ -7444,7 +7858,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "timespan": {
@@ -7460,7 +7874,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-array": {
@@ -7492,7 +7906,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -7524,7 +7938,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -7539,7 +7953,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -7555,7 +7969,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "type-of-is": {
@@ -7597,7 +8011,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -7641,8 +8055,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
-        "tmp": "0.0.33"
+        "lru-cache": "2.2.x",
+        "tmp": "0.0.x"
       },
       "dependencies": {
         "lru-cache": {
@@ -7698,8 +8112,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "validator": {
@@ -7712,9 +8126,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -7744,7 +8158,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -7764,8 +8178,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -7773,9 +8187,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -7791,9 +8205,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xml2js": {
@@ -7801,8 +8215,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -7844,19 +8258,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
       "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       }
     },
     "yargs-parser": {
@@ -7864,7 +8278,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {
@@ -7873,7 +8287,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeast": {
@@ -7887,10 +8301,10 @@
       "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
       "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
       "requires": {
-        "commander": "2.15.1",
-        "lodash.get": "4.4.2",
-        "lodash.isequal": "4.5.0",
-        "validator": "9.4.1"
+        "commander": "^2.7.1",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^9.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,137 +6,130 @@
   "dependencies": {
     "JSONSelect": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/JSONSelect/-/JSONSelect-0.4.0.tgz",
       "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40="
     },
     "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "version": "1.3.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/JSONStream/-/JSONStream-1.3.4.tgz",
+      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.20",
         "negotiator": "0.6.1"
       }
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "5.7.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/acorn/-/acorn-5.7.2.tgz",
+      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
       "dev": true
     },
-    "acorn-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
-      "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
+    "acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "^5.4.1",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        }
+        "acorn": "5.7.2"
+      }
+    },
+    "acorn-node": {
+      "version": "1.5.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/acorn-node/-/acorn-node-1.5.2.tgz",
+      "integrity": "sha512-krFKvw/d1F17AN3XZbybIUzEY4YEPNiGo05AfP3dBlfVKrMHETKpgjpuZkSF8qDNt9UkQcqj7am8yJLseklCMg==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.7.2",
+        "acorn-dynamic-import": "3.0.0",
+        "xtend": "4.0.1"
       }
     },
     "addressparser": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/addressparser/-/addressparser-1.0.1.tgz",
       "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=",
       "dev": true,
       "optional": true
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
       "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "amqplib": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/amqplib/-/amqplib-0.5.2.tgz",
       "integrity": "sha512-l9mCs6LbydtHqRniRwYkKdqxVa6XMz3Vw1fh+2gJaaVgTM6Jk3o8RccAKWKtlhT1US5sWrFh+KKxsVUALURSIA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "bitsyntax": "~0.0.4",
-        "bluebird": "^3.4.6",
+        "bitsyntax": "0.0.4",
+        "bluebird": "3.5.2",
         "buffer-more-ints": "0.0.2",
-        "readable-stream": "1.x >=1.1.9",
-        "safe-buffer": "^5.0.1"
+        "readable-stream": "1.1.14",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true,
           "optional": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true,
           "optional": true
@@ -145,194 +138,220 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "version": "2.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       }
     },
     "apib-include-directive": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/apib-include-directive/-/apib-include-directive-0.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/apib-include-directive/-/apib-include-directive-0.1.0.tgz",
       "integrity": "sha1-YQg+4aZgwsMo90c/tkMYEqZabLU="
     },
     "apib2swagger": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/apib2swagger/-/apib2swagger-1.0.0.tgz",
-      "integrity": "sha1-zJjvbrd3RunNi5oi2cEDS7PV830=",
+      "version": "1.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/apib2swagger/-/apib2swagger-1.1.1.tgz",
+      "integrity": "sha1-pMFSYz0TEH2w8cD48VP6UptQdbI=",
       "requires": {
-        "apib-include-directive": "^0.1.0",
-        "drafter.js": "^2.6.2",
-        "generate-schema": "^2.5.0",
-        "js-yaml": "^3.9.1",
-        "nopt": "^3.0.6",
-        "uritemplate": "^0.3.4"
+        "apib-include-directive": "0.1.0",
+        "drafter.js": "2.6.7",
+        "generate-schema": "2.6.0",
+        "js-yaml": "3.12.0",
+        "nopt": "3.0.6",
+        "uritemplate": "0.3.4"
       }
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-filter": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
     "array-map": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
       "dev": true
     },
     "array-reduce": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
     "array-slice": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/array-slice/-/array-slice-0.2.3.tgz",
       "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "version": "0.3.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true,
       "requires": {
         "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
       }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "ast-types": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-      "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+      "version": "0.11.5",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ast-types/-/ast-types-0.11.5.tgz",
+      "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
       "dev": true,
       "optional": true
     },
-    "astw": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
-      "dev": true,
-      "requires": {
-        "acorn": "^4.0.3"
-      }
-    },
     "async": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "version": "2.6.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.10"
       }
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "version": "1.8.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
       "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/axios/-/axios-0.15.3.tgz",
       "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
       "dev": true,
       "optional": true,
@@ -342,7 +361,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -352,57 +371,57 @@
         },
         "follow-redirects": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/follow-redirects/-/follow-redirects-1.0.0.tgz",
           "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.2.0"
+            "debug": "2.6.9"
           }
         }
       }
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "debug": "^2.6.8",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.7",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -411,7 +430,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -419,29 +438,29 @@
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -449,561 +468,561 @@
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "version": "6.26.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-polyfill": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
       }
     },
     "babel-preset-env": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "version": "1.7.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^2.1.2",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.4",
+        "semver": "5.5.1"
       }
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-register": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         }
@@ -1011,37 +1030,37 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -1052,74 +1071,129 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.14",
-        "object-assign": "^4.0.0"
+        "babel-core": "6.26.3",
+        "object-assign": "4.1.1"
       }
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "base64-arraybuffer": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+      "version": "1.3.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "base64id": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
@@ -1128,13 +1202,13 @@
     },
     "binary-extensions": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bitsyntax": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/bitsyntax/-/bitsyntax-0.0.4.tgz",
       "integrity": "sha1-6xDMb4K4xJDj6FaY8H6D1G4MuoI=",
       "dev": true,
       "optional": true,
@@ -1144,39 +1218,39 @@
     },
     "bl": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "~2.0.5"
+        "readable-stream": "2.0.6"
       },
       "dependencies": {
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true,
           "optional": true
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true,
           "optional": true
@@ -1185,103 +1259,131 @@
     },
     "blob": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
-        "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
         }
       }
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "2.3.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-pack": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.4.tgz",
-      "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
+      "version": "6.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.8.0",
-        "defined": "^1.0.0",
-        "safe-buffer": "^5.1.1",
-        "through2": "^2.0.0",
-        "umd": "^3.0.0"
+        "JSONStream": "1.3.4",
+        "combine-source-map": "0.8.0",
+        "defined": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "through2": "2.0.3",
+        "umd": "3.0.3"
       }
     },
     "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "version": "1.11.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "dev": true,
       "requires": {
         "resolve": "1.1.7"
@@ -1289,7 +1391,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -1297,173 +1399,202 @@
     },
     "browserify": {
       "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify/-/browserify-13.3.0.tgz",
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "assert": "^1.4.0",
-        "browser-pack": "^6.0.1",
-        "browser-resolve": "^1.11.0",
-        "browserify-zlib": "~0.1.2",
-        "buffer": "^4.1.0",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "~1.5.1",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "~1.0.0",
-        "crypto-browserify": "^3.0.0",
-        "defined": "^1.0.0",
-        "deps-sort": "^2.0.0",
-        "domain-browser": "~1.1.0",
-        "duplexer2": "~0.1.2",
-        "events": "~1.1.0",
-        "glob": "^7.1.0",
-        "has": "^1.0.0",
-        "htmlescape": "^1.1.0",
-        "https-browserify": "~0.0.0",
-        "inherits": "~2.0.1",
-        "insert-module-globals": "^7.0.0",
-        "labeled-stream-splicer": "^2.0.0",
-        "module-deps": "^4.0.8",
-        "os-browserify": "~0.1.1",
-        "parents": "^1.0.1",
-        "path-browserify": "~0.0.0",
-        "process": "~0.11.0",
-        "punycode": "^1.3.2",
-        "querystring-es3": "~0.2.0",
-        "read-only-stream": "^2.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.1.4",
-        "shasum": "^1.0.0",
-        "shell-quote": "^1.6.1",
-        "stream-browserify": "^2.0.0",
-        "stream-http": "^2.0.0",
-        "string_decoder": "~0.10.0",
-        "subarg": "^1.0.0",
-        "syntax-error": "^1.1.1",
-        "through2": "^2.0.0",
-        "timers-browserify": "^1.0.1",
-        "tty-browserify": "~0.0.0",
-        "url": "~0.11.0",
-        "util": "~0.10.1",
-        "vm-browserify": "~0.0.1",
-        "xtend": "^4.0.0"
+        "JSONStream": "1.3.4",
+        "assert": "1.4.1",
+        "browser-pack": "6.1.0",
+        "browser-resolve": "1.11.3",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "defined": "1.0.0",
+        "deps-sort": "2.0.0",
+        "domain-browser": "1.1.7",
+        "duplexer2": "0.1.4",
+        "events": "1.1.1",
+        "glob": "7.1.3",
+        "has": "1.0.3",
+        "htmlescape": "1.1.1",
+        "https-browserify": "0.0.1",
+        "inherits": "2.0.3",
+        "insert-module-globals": "7.2.0",
+        "labeled-stream-splicer": "2.0.1",
+        "module-deps": "4.1.1",
+        "os-browserify": "0.1.2",
+        "parents": "1.0.1",
+        "path-browserify": "0.0.1",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "read-only-stream": "2.0.0",
+        "readable-stream": "2.3.6",
+        "resolve": "1.8.1",
+        "shasum": "1.0.2",
+        "shell-quote": "1.6.1",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.3",
+        "string_decoder": "0.10.31",
+        "subarg": "1.0.0",
+        "syntax-error": "1.4.0",
+        "through2": "2.0.3",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.1",
+        "url": "0.11.0",
+        "util": "0.10.4",
+        "vm-browserify": "0.0.4",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "browserify-aes": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+      "version": "1.2.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "version": "1.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.1",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
       }
     },
     "browserify-zlib": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "~0.2.0"
+        "pako": "0.2.9"
       }
     },
     "browserslist": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "version": "3.2.8",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000792",
-        "electron-to-chromium": "^1.3.30"
+        "caniuse-lite": "1.0.30000884",
+        "electron-to-chromium": "1.3.62"
       }
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-more-ints": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
       "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw=",
       "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "buildmail": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-4.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/buildmail/-/buildmail-4.0.1.tgz",
       "integrity": "sha1-h393OLeHKYccmhBeO4N9K+EaenI=",
       "dev": true,
       "optional": true,
@@ -1479,1133 +1610,281 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
     "cached-path-relative": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
       "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
       "dev": true
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "camelcase": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "caniuse-lite": {
-      "version": "1.0.30000810",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
-      "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA==",
+      "version": "1.0.30000884",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz",
+      "integrity": "sha512-ibROerckpTH6U5zReSjbaitlH4gl5V4NWNCBzRNCa3GEDmzzkfStk+2k5mO4ZDM6pwtdjbZ3hjvsYhPGVLWgNw==",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chai-as-promised": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
       "dev": true
     },
     "chai-dom": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.7.0.tgz",
-      "integrity": "sha512-yUkuqa+3tLzFenmaEcRtSKzAvs/aYusNXHjnN8g5t7deC+9WPx9Fecfz63cM5ZJtfKbvQqFrmY8tsjOCyzrZEQ==",
+      "version": "1.8.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chai-dom/-/chai-dom-1.8.0.tgz",
+      "integrity": "sha512-MNw5x1gyH++fEJkaPOCLLH78ftL7Of2/KI4YPyttVrwTC36GRQe21H66mIn1Pb/O6psHoHEz/SDLFoQTTLxxvA==",
       "dev": true
     },
     "chai-jquery": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chai-jquery/-/chai-jquery-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chai-jquery/-/chai-jquery-2.0.0.tgz",
       "integrity": "sha1-D0MEIwjddGMyvZgWSq70pPRboWc=",
       "dev": true
     },
     "chai-things": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chai-things/-/chai-things-0.2.0.tgz",
       "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
       "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "chance": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/chance/-/chance-0.8.0.tgz",
-      "integrity": "sha1-tIt/Hxa3/MHESW/S5uv/8T9H7SQ="
+      "version": "1.0.16",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chance/-/chance-1.0.16.tgz",
+      "integrity": "sha512-2bgDHH5bVfAXH05SPtjqrsASzZ7h90yCuYT2z4mkYpxxYvJXiIydBFzVieVHZx7wLH1Ag2Azaaej2/zA1XUrNQ=="
     },
     "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "version": "2.0.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/chokidar/-/chokidar-2.0.4.tgz",
+      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "1.1.3",
-          "resolved": "http://artifacts.apiture.com/repository/npm-group/fsevents/-/fsevents-1.1.3.tgz",
-          "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "nan": "^2.3.0",
-            "node-pre-gyp": "^0.6.39"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "aproba": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true,
-              "dev": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "^0.14.3"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "~2.0.0"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hoek": "2.x.x"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^0.4.1",
-                "concat-map": "0.0.1"
-              }
-            },
-            "buffer-shims": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "boom": "2.x.x"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "^1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "~0.1.0"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "fstream": "^1.0.0",
-                "inherits": "2",
-                "minimatch": "^3.0.0"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "^1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true,
-              "dev": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true,
-              "dev": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "^0.2.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "~0.1.0"
-              }
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsonify": "~0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.0.2",
-                "json-schema": "0.2.3",
-                "verror": "1.3.6"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "bundled": true,
-              "dev": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mime-db": "~1.27.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.39",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "hawk": "3.1.3",
-                "mkdirp": "^0.5.1",
-                "nopt": "^4.0.1",
-                "npmlog": "^4.0.2",
-                "rc": "^1.1.7",
-                "request": "2.81.0",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^2.2.1",
-                "tar-pack": "^3.4.0"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true,
-              "dev": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "~0.4.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer-shims": "~1.0.0",
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hoek": "2.x.x"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jodid25519": "^1.0.0",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "fstream": "^1.0.10",
-                "fstream-ignore": "^1.0.5",
-                "once": "^1.3.3",
-                "readable-stream": "^2.1.4",
-                "rimraf": "^2.5.1",
-                "tar": "^2.2.1",
-                "uid-number": "^0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.3.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "extsprintf": "1.0.2"
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        }
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.4",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "lodash.debounce": "4.0.8",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0",
+        "upath": "1.1.0"
       }
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "circular-json": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.3.tgz",
-      "integrity": "sha512-YlxLOimeIoQGHnMe3kbf8qIV2Bj7uXLbljMPRguNT49GmSAzooNfS9EJ91rSJKbLBOOzM5agvtx0WyechZN/Hw==",
+      "version": "0.5.5",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/circular-json/-/circular-json-0.5.5.tgz",
+      "integrity": "sha512-13YaR6kiz0kBNmIVM87Io8Hp7bWOo4r61vkEANy8iH9R9bc6avud/1FT0SBpqR1RpIQADOh/Q+yHZDA1iL6ysA==",
       "dev": true
     },
     "cjson": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cjson/-/cjson-0.2.1.tgz",
       "integrity": "sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU="
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/colors/-/colors-0.5.1.tgz",
       "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
     },
     "combine-lists": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "^4.5.0"
+        "lodash": "4.17.10"
       }
     },
     "combine-source-map": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/combine-source-map/-/combine-source-map-0.8.0.tgz",
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "~1.1.0",
-        "inline-source-map": "~0.6.0",
-        "lodash.memoize": "~3.0.3",
-        "source-map": "~0.5.3"
+        "convert-source-map": "1.1.3",
+        "inline-source-map": "0.6.2",
+        "lodash.memoize": "3.0.4",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -2613,84 +1892,84 @@
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "2.17.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "common-prefix": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/common-prefix/-/common-prefix-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/common-prefix/-/common-prefix-1.1.0.tgz",
       "integrity": "sha1-46Xqf6+u/H64TnYFI+GvuYX5DwA="
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "composite-error": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/composite-error/-/composite-error-0.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/composite-error/-/composite-error-0.1.1.tgz",
       "integrity": "sha1-pOwznDeUvH41ZBK5FUgZlf74Jyc="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/concat-stream/-/concat-stream-1.5.2.tgz",
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~2.0.0",
-        "typedarray": "~0.0.5"
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -2698,19 +1977,19 @@
     },
     "connect": {
       "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -2721,172 +2000,171 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "cookie": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+      "version": "2.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.7",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "version": "4.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.1"
       }
     },
     "create-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "version": "1.2.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+      "version": "1.1.7",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "optional": true,
       "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
+        "boom": "2.10.1"
       }
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.16",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "custom-event": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
       "dev": true,
       "optional": true
     },
     "date-format": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/date-format/-/date-format-1.2.0.tgz",
       "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
       "dev": true
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "debug": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
@@ -2894,12 +2172,18 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
@@ -2908,7 +2192,7 @@
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/type-detect/-/type-detect-0.1.1.tgz",
           "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
@@ -2916,72 +2200,113 @@
     },
     "deep-extend": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true,
       "optional": true
     },
     "deep-sort-object": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/deep-sort-object/-/deep-sort-object-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/deep-sort-object/-/deep-sort-object-1.0.2.tgz",
       "integrity": "sha1-OJLc7139Dvwtb6lr6rzLM82O+R8=",
       "requires": {
-        "is-plain-object": "^2.0.1"
+        "is-plain-object": "2.0.4"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
       }
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "degenerator": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "dev": true,
       "optional": true,
       "requires": {
-        "ast-types": "0.x.x",
-        "escodegen": "1.x.x",
-        "esprima": "3.x.x"
+        "ast-types": "0.11.5",
+        "escodegen": "1.11.0",
+        "esprima": "3.1.3"
       },
       "dependencies": {
         "escodegen": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+          "version": "1.11.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/escodegen/-/escodegen-1.11.0.tgz",
+          "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
           "dev": true,
           "optional": true,
           "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.6.1"
           }
         },
         "esprima": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         },
         "estraverse": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/estraverse/-/estraverse-4.2.0.tgz",
           "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
           "dev": true,
           "optional": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
@@ -2990,579 +2315,668 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "deps-sort": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "shasum": "^1.0.0",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0"
+        "JSONStream": "1.3.4",
+        "shasum": "1.0.2",
+        "subarg": "1.0.0",
+        "through2": "2.0.3"
       }
     },
     "deref": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/deref/-/deref-0.6.4.tgz",
       "integrity": "sha1-vVqW1F2+0wEbuBvfaN31S+jhvU4=",
       "requires": {
-        "deep-extend": "^0.4.0"
+        "deep-extend": "0.4.2"
       }
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detective": {
       "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/detective/-/detective-4.7.1.tgz",
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        }
+        "acorn": "5.7.2",
+        "defined": "1.0.0"
       }
     },
     "di": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
     "diff": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
     "diffie-hellman": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "version": "5.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dom-serialize": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.2",
+        "void-elements": "2.0.1"
       }
     },
     "domain-browser": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
       "dev": true,
       "optional": true
     },
     "drafter.js": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/drafter.js/-/drafter.js-2.6.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/drafter.js/-/drafter.js-2.6.7.tgz",
       "integrity": "sha1-WcQ6hYZSc0DLNb3cVBgFWfru8AE="
     },
     "drange": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/drange/-/drange-1.0.0.tgz",
-      "integrity": "sha512-G3nVX4X4um76RWKzA+OMovFQdjU4rfEsC1NsDNQXgMvtZ14btchzckaOiXSHHvJAttqEXr4uG5g9EJEoidinQg=="
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/drange/-/drange-1.0.2.tgz",
+      "integrity": "sha512-bve7maXvfKW+vcsRpP8gzEDzkTg8O6AoCGvi/52pnllzhl/nmex8XLrHOUEQ42Z8GshcyftvG+E4s5vcd/qo0Q=="
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexify": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
-      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+      "version": "3.6.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ebnf-parser": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
       "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE="
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.34",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
-      "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0=",
+      "version": "1.3.62",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
+      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "version": "6.4.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.5",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.24"
       }
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/engine.io/-/engine.io-3.1.5.tgz",
       "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "uws": "~9.14.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "uws": "9.14.0",
+        "ws": "3.3.3"
       }
     },
     "engine.io-client": {
       "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/engine.io-client/-/engine.io-client-3.1.6.tgz",
       "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       }
     },
     "engine.io-parser": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "ent": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es6-promise": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.4"
       }
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escodegen": {
       "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/escodegen/-/escodegen-0.0.21.tgz",
       "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
       "requires": {
-        "esprima": "~1.0.2",
-        "estraverse": "~0.0.4",
-        "source-map": ">= 0.1.2"
+        "esprima": "1.0.4",
+        "estraverse": "0.0.4",
+        "source-map": "0.6.0"
       },
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
         }
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "version": "4.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estraverse": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/estraverse/-/estraverse-0.0.4.tgz",
       "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI="
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "eventemitter3": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/eventemitter3/-/eventemitter3-3.1.0.tgz",
       "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
       }
     },
     "execa": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-braces": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "braces": "^0.1.2"
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
       },
       "dependencies": {
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
         "braces": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "^0.1.0"
+            "expand-range": "0.1.1"
           }
-        },
-        "expand-range": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
-          "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-          "dev": true,
-          "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
-          }
-        },
-        "is-number": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
-          "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
-          "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
-          "dev": true
         }
       }
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "version": "2.1.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
-      }
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^1.0.0"
-      }
-    },
-    "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
-        "yauzl": "2.4.1"
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "expand-range": {
+      "version": "0.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/expand-range/-/expand-range-0.1.1.tgz",
+      "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
+      "dev": true,
+      "requires": {
+        "is-number": "0.1.1",
+        "repeat-string": "0.2.2"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "0.1.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-number/-/is-number-0.1.1.tgz",
+          "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "0.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/repeat-string/-/repeat-string-0.2.2.tgz",
+          "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "faker": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/faker/-/faker-3.1.0.tgz",
       "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true,
       "optional": true
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true,
       "optional": true
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "4.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "isarray": "1.0.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
     },
     "finalhandler": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -3571,7 +2985,7 @@
         },
         "statuses": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/statuses/-/statuses-1.3.1.tgz",
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
@@ -3579,93 +2993,93 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "follow-redirects": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "version": "1.5.7",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       }
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "^1.0.1"
-      }
-    },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.20"
       }
     },
     "format-util": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/format-util/-/format-util-1.0.3.tgz",
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.1.2"
       }
     },
     "formidable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+      "version": "1.2.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "^1.0.0"
+        "null-check": "1.0.0"
       }
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -3673,14 +3087,16 @@
       "version": "1.2.4",
       "resolved": "http://artifacts.apiture.com/repository/npm-group/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.11.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -3688,14 +3104,16 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -3706,13 +3124,14 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -3728,88 +3147,101 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -3818,24 +3250,26 @@
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -3846,15 +3280,16 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -3866,61 +3301,68 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -3929,73 +3371,83 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -4004,73 +3456,83 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -4085,38 +3547,38 @@
     },
     "ftp": {
       "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ftp/-/ftp-0.3.10.tgz",
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "xregexp": "2.0.0"
       },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true,
           "optional": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true,
           "optional": true
@@ -4125,64 +3587,73 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "version": "2.3.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "optional": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "generate-schema": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/generate-schema/-/generate-schema-2.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/generate-schema/-/generate-schema-2.6.0.tgz",
       "integrity": "sha512-EUBKfJNzT8f91xUk5X5gKtnbdejZeE065UAJ3BCzE8VEbvwKI9Pm5jaWmqVeK1MYc1g5weAVFDTSJzN7ymtTqA==",
       "requires": {
-        "commander": "^2.9.0",
-        "type-of-is": "^3.4.0"
+        "commander": "2.17.1",
+        "type-of-is": "3.5.1"
       }
     },
+    "get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true
+    },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "version": "1.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.1.tgz",
-      "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
+      "version": "2.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/get-uri/-/get-uri-2.0.2.tgz",
+      "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "data-uri-to-buffer": "1",
-        "debug": "2",
-        "extend": "3",
-        "file-uri-to-path": "1",
-        "ftp": "~0.3.10",
-        "readable-stream": "2"
+        "data-uri-to-buffer": "1.2.0",
+        "debug": "2.6.9",
+        "extend": "3.0.2",
+        "file-uri-to-path": "1.0.0",
+        "ftp": "0.3.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -4192,145 +3663,153 @@
         }
       }
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "3.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
       }
     },
     "globals": {
       "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "google-discovery-to-swagger": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/google-discovery-to-swagger/-/google-discovery-to-swagger-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/google-discovery-to-swagger/-/google-discovery-to-swagger-2.0.0.tgz",
       "integrity": "sha1-L52qedOx4rJlFopjK3eMsjrwpoo=",
       "requires": {
-        "json-schema-compatibility": "^1.1.0",
-        "jsonpath": "^0.2.2",
-        "lodash": "^4.1.0",
-        "mime-db": "^1.21.0",
-        "mime-lookup": "^0.0.2",
-        "traverse": "~0.6.6",
-        "urijs": "^1.17.0"
+        "json-schema-compatibility": "1.1.0",
+        "jsonpath": "0.2.12",
+        "lodash": "4.17.10",
+        "mime-db": "1.36.0",
+        "mime-lookup": "0.0.2",
+        "traverse": "0.6.6",
+        "urijs": "1.19.1"
       }
     },
     "got": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/got/-/got-2.4.0.tgz",
       "integrity": "sha1-5Ah6LNWbXSDy0WnchdIWntnon1Y=",
       "requires": {
-        "duplexify": "^3.2.0",
-        "infinity-agent": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "prepend-http": "^1.0.0",
-        "read-all-stream": "^1.0.0",
-        "statuses": "^1.2.1",
-        "timed-out": "^2.0.0"
+        "duplexify": "3.6.0",
+        "infinity-agent": "1.0.2",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "object-assign": "2.1.1",
+        "prepend-http": "1.0.4",
+        "read-all-stream": "1.0.2",
+        "statuses": "1.5.0",
+        "timed-out": "2.0.0"
       },
       "dependencies": {
         "object-assign": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/object-assign/-/object-assign-2.1.1.tgz",
           "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
         }
       }
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphlib": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/graphlib/-/graphlib-2.1.5.tgz",
       "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
-        "lodash": "^4.11.1"
+        "lodash": "4.17.10"
       }
     },
     "growl": {
       "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-      "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+      "version": "1.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "dev": true,
       "requires": {
         "isarray": "2.0.1"
@@ -4338,7 +3817,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -4346,509 +3825,564 @@
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "hash-base": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "version": "1.1.5",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hasha": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "3.1.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "optional": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "hipchat-notifier": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hipchat-notifier/-/hipchat-notifier-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hipchat-notifier/-/hipchat-notifier-1.1.0.tgz",
       "integrity": "sha1-ttJJdVQ3wZEII2d5nTupoPI7Ix4=",
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "^4.0.0",
-        "request": "^2.0.0"
+        "lodash": "4.17.10",
+        "request": "2.88.0"
       }
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.5",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "version": "2.16.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.7.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       }
     },
     "http-proxy": {
       "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.7",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
+      "version": "2.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
       }
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "http-status-codes": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/http-status-codes/-/http-status-codes-1.3.0.tgz",
       "integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y="
     },
     "httpntlm": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
       "requires": {
-        "httpreq": ">=0.4.22",
-        "underscore": "~1.7.0"
+        "httpreq": "0.4.24",
+        "underscore": "1.7.0"
       }
     },
     "httpreq": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
       "dev": true
     },
     "https-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "version": "0.4.24",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "version": "1.1.12",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "infinity-agent": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/infinity-agent/-/infinity-agent-1.0.2.tgz",
       "integrity": "sha1-Lp2iwHC5hkqLxmwBlOF5HtgFgCU="
     },
     "inflection": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
-      "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8=",
+      "version": "1.12.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
       "dev": true,
       "optional": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inline-source-map": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "~0.5.3"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "insert-module-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+      "version": "7.2.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+      "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.7.1",
-        "concat-stream": "~1.5.1",
-        "is-buffer": "^1.1.0",
-        "lexical-scope": "^1.2.0",
-        "process": "~0.11.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.0"
+        "JSONStream": "1.3.4",
+        "acorn-node": "1.5.2",
+        "combine-source-map": "0.8.0",
+        "concat-stream": "1.6.2",
+        "is-buffer": "1.1.6",
+        "path-is-absolute": "1.0.1",
+        "process": "0.11.10",
+        "through2": "2.0.3",
+        "undeclared-identifiers": "1.1.2",
+        "xtend": "4.0.1"
       },
       "dependencies": {
-        "combine-source-map": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
-          "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "convert-source-map": "~1.1.0",
-            "inline-source-map": "~0.6.0",
-            "lodash.memoize": "~3.0.3",
-            "source-map": "~0.5.3"
+            "buffer-from": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
-        },
-        "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-          "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
-      "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
+      "version": "1.1.5",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
-      "optional": true
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "version": "2.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "version": "4.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
       "dev": true,
       "optional": true
     },
     "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "version": "2.19.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.3.1",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "version": "3.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
-      "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+      "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc": "1.2.0"
+      }
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jade": {
       "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
       "dev": true,
       "requires": {
@@ -4858,13 +4392,13 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
@@ -4872,174 +4406,174 @@
     },
     "jgexml": {
       "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/jgexml/-/jgexml-0.3.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jgexml/-/jgexml-0.3.8.tgz",
       "integrity": "sha512-WKxxkEInMFCnUXk6QpCQWMVyUEgiasTeP9TLbMvPoaTq5Wvf0bG+w7k5Fn3QQ8GOqUJHcHUGw/kQiYEBXR7xyQ=="
     },
     "jison": {
       "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.13.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jison/-/jison-0.4.13.tgz",
       "integrity": "sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=",
       "requires": {
         "JSONSelect": "0.4.0",
-        "cjson": "~0.2.1",
-        "ebnf-parser": "~0.1.9",
+        "cjson": "0.2.1",
+        "ebnf-parser": "0.1.10",
         "escodegen": "0.0.21",
-        "esprima": "1.0.x",
-        "jison-lex": "0.2.x",
-        "lex-parser": "~0.1.3",
+        "esprima": "1.0.4",
+        "jison-lex": "0.2.1",
+        "lex-parser": "0.1.4",
         "nomnom": "1.5.2"
       },
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
         }
       }
     },
     "jison-lex": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jison-lex/-/jison-lex-0.2.1.tgz",
       "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4=",
       "requires": {
-        "lex-parser": "0.1.x",
+        "lex-parser": "0.1.4",
         "nomnom": "1.5.2"
       }
     },
     "jju": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jju/-/jju-1.2.1.tgz",
       "integrity": "sha1-7fbsINXWaMgMLADOpj+KlCKktSg="
     },
     "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+      "version": "2.4.9",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/js-base64/-/js-base64-2.4.9.tgz",
+      "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.12.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
     "json-refs": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-refs/-/json-refs-2.1.7.tgz",
       "integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
       "requires": {
-        "commander": "^2.9.0",
-        "graphlib": "^2.1.1",
-        "js-yaml": "^3.8.3",
-        "native-promise-only": "^0.8.1",
-        "path-loader": "^1.0.2",
-        "slash": "^1.0.0",
-        "uri-js": "^3.0.2"
+        "commander": "2.17.1",
+        "graphlib": "2.1.5",
+        "js-yaml": "3.12.0",
+        "native-promise-only": "0.8.1",
+        "path-loader": "1.0.8",
+        "slash": "1.0.0",
+        "uri-js": "3.0.2"
       }
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-compatibility": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-compatibility/-/json-schema-compatibility-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-schema-compatibility/-/json-schema-compatibility-1.1.0.tgz",
       "integrity": "sha1-GomBd4zaDDgYcpjZmdCJ5Rrygt8="
     },
     "json-schema-faker": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.2.8.tgz",
-      "integrity": "sha1-rGmxuzaCiPfw/IxzB57jP8TCQL0=",
+      "version": "0.2.16",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-schema-faker/-/json-schema-faker-0.2.16.tgz",
+      "integrity": "sha1-UdPKSJVdj+c09ZHXR7ckU75aePI=",
       "requires": {
-        "chance": "^0.8.0",
-        "deref": "^0.6.3",
-        "faker": "^3.0.1",
-        "randexp": "^0.4.2"
+        "chance": "1.0.16",
+        "deref": "0.6.4",
+        "faker": "3.1.0",
+        "randexp": "0.4.9"
       }
     },
     "json-schema-ref-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.3.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-schema-ref-parser/-/json-schema-ref-parser-3.3.1.tgz",
       "integrity": "sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "debug": "^3.0.0",
-        "es6-promise": "^4.1.1",
-        "js-yaml": "^3.9.1",
-        "ono": "^4.0.2",
-        "z-schema": "^3.18.2"
+        "call-me-maybe": "1.0.1",
+        "debug": "3.1.0",
+        "es6-promise": "4.2.4",
+        "js-yaml": "3.12.0",
+        "ono": "4.0.7",
+        "z-schema": "3.23.0"
       }
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpath": {
       "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-0.2.12.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsonpath/-/jsonpath-0.2.12.tgz",
       "integrity": "sha1-W/nZEftGFsHjNwvs658NskrjTNI=",
       "requires": {
         "esprima": "1.2.2",
@@ -5050,21 +4584,21 @@
       "dependencies": {
         "esprima": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/esprima/-/esprima-1.2.2.tgz",
           "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
         }
       }
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true,
       "optional": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -5074,49 +4608,49 @@
       }
     },
     "karma": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.2.tgz",
-      "integrity": "sha1-TS25QChQpmVR+nhLAWT7CCTtjEs=",
+      "version": "2.0.5",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/karma/-/karma-2.0.5.tgz",
+      "integrity": "sha512-rECezBeY7mjzGUWhFlB7CvPHgkHJLXyUmWg+6vHCEsdWNUTnmiS6jRrIMcJEWgU2DUGZzGWG0bTRVky8fsDTOA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
-        "chokidar": "^1.4.1",
-        "colors": "^1.1.0",
-        "combine-lists": "^1.0.0",
-        "connect": "^3.6.0",
-        "core-js": "^2.2.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "expand-braces": "^0.1.1",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.4",
-        "log4js": "^2.3.9",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
+        "bluebird": "3.5.2",
+        "body-parser": "1.18.3",
+        "chokidar": "2.0.4",
+        "colors": "1.3.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.6",
+        "core-js": "2.5.7",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.17.0",
+        "isbinaryfile": "3.0.3",
+        "lodash": "4.17.10",
+        "log4js": "2.11.0",
+        "mime": "1.6.0",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.2.0",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
         "socket.io": "2.0.4",
-        "source-map": "^0.6.1",
+        "source-map": "0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.2.1"
       },
       "dependencies": {
         "colors": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
-          "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ==",
+          "version": "1.3.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/colors/-/colors-1.3.2.tgz",
+          "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -5124,32 +4658,32 @@
     },
     "karma-chai-plugins": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/karma-chai-plugins/-/karma-chai-plugins-0.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/karma-chai-plugins/-/karma-chai-plugins-0.7.0.tgz",
       "integrity": "sha1-XgvEQ6taYOvkbxcJXgnHXK8MML4=",
       "dev": true,
       "requires": {
-        "chai": "^3.4.1",
-        "chai-as-promised": "^5.1.0",
-        "chai-dom": "^1.2.2",
-        "chai-jquery": "^2.0.0",
-        "chai-things": "^0.2.0",
-        "sinon": "^1.17.2",
-        "sinon-chai": "^2.8.0"
+        "chai": "3.5.0",
+        "chai-as-promised": "5.3.0",
+        "chai-dom": "1.8.0",
+        "chai-jquery": "2.0.0",
+        "chai-things": "0.2.0",
+        "sinon": "1.17.7",
+        "sinon-chai": "2.14.0"
       }
     },
     "karma-chrome-launcher": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
-        "fs-access": "^1.0.0",
-        "which": "^1.2.1"
+        "fs-access": "1.0.1",
+        "which": "1.3.1"
       }
     },
     "karma-mocha": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/karma-mocha/-/karma-mocha-1.3.0.tgz",
       "integrity": "sha1-7qrH/8DiAetjxGdEDStpx883eL8=",
       "dev": true,
       "requires": {
@@ -5158,7 +4692,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5166,156 +4700,144 @@
     },
     "karma-mocha-reporter": {
       "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
       "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
       "dev": true,
       "requires": {
-        "chalk": "^2.1.0",
-        "log-symbols": "^2.1.0",
-        "strip-ansi": "^4.0.0"
+        "chalk": "2.4.1",
+        "log-symbols": "2.2.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "version": "2.4.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.2.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.5.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "karma-phantomjs-launcher": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
+        "lodash": "4.17.10",
+        "phantomjs-prebuilt": "2.1.16"
       }
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
+      "version": "6.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "labeled-stream-splicer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
-      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+      "version": "2.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "isarray": "~0.0.1",
-        "stream-splicer": "^2.0.0"
+        "inherits": "2.0.3",
+        "isarray": "2.0.4",
+        "stream-splicer": "2.0.0"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "version": "2.0.4",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-2.0.4.tgz",
+          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
           "dev": true
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "optional": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lex-parser": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lex-parser/-/lex-parser-0.1.4.tgz",
       "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA="
-    },
-    "lexical-scope": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
-      "dev": true,
-      "requires": {
-        "astw": "^2.0.0"
-      }
     },
     "libbase64": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
       "dev": true
     },
     "libmime": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
       "requires": {
@@ -5326,7 +4848,7 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.15",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
           "dev": true
         }
@@ -5334,277 +4856,252 @@
     },
     "libqp": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
       "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
       "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.memoize": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "version": "2.4.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.2.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.5.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "log4js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.3.tgz",
-      "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
+      "version": "2.11.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/log4js/-/log4js-2.11.0.tgz",
+      "integrity": "sha512-z1XdwyGFg8/WGkOyF6DPJjivCWNLKrklGdViywdYnSKOvgtEBo2UyEMZS5sD2mZrQlU3TvO8wDWLc8mzE1ncBQ==",
       "dev": true,
       "requires": {
-        "amqplib": "^0.5.2",
-        "axios": "^0.15.3",
-        "circular-json": "^0.5.1",
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "hipchat-notifier": "^1.1.0",
-        "loggly": "^1.1.0",
-        "mailgun-js": "^0.7.0",
-        "nodemailer": "^2.5.0",
-        "redis": "^2.7.1",
-        "semver": "^5.3.0",
-        "slack-node": "~0.2.0",
-        "streamroller": "^0.7.0"
+        "amqplib": "0.5.2",
+        "axios": "0.15.3",
+        "circular-json": "0.5.5",
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "hipchat-notifier": "1.1.0",
+        "loggly": "1.1.1",
+        "mailgun-js": "0.18.1",
+        "nodemailer": "2.7.2",
+        "redis": "2.8.0",
+        "semver": "5.5.1",
+        "slack-node": "0.2.0",
+        "streamroller": "0.7.0"
       }
     },
     "loggly": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/loggly/-/loggly-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/loggly/-/loggly-1.1.1.tgz",
       "integrity": "sha1-Cg/B0/o6XsRP3HuJe+uipGlc6+4=",
       "dev": true,
       "optional": true,
       "requires": {
-        "json-stringify-safe": "5.0.x",
-        "request": "2.75.x",
-        "timespan": "2.3.x"
+        "json-stringify-safe": "5.0.1",
+        "request": "2.75.0",
+        "timespan": "2.3.0"
       },
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/assert-plus/-/assert-plus-0.2.0.tgz",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
         "caseless": {
           "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true,
           "optional": true
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
         "form-data": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/form-data/-/form-data-2.0.0.tgz",
           "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.20"
           }
         },
         "har-validator": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "chalk": "1.1.3",
+            "commander": "2.17.1",
+            "is-my-json-valid": "2.19.0",
+            "pinkie-promise": "2.0.1"
           }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
           }
         },
         "node-uuid": {
           "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/node-uuid/-/node-uuid-1.4.8.tgz",
           "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true,
+          "optional": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/qs/-/qs-6.2.3.tgz",
           "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
           "dev": true,
           "optional": true
         },
         "request": {
           "version": "2.75.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/request/-/request-2.75.0.tgz",
           "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "bl": "~1.1.2",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.0.0",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.8.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.20",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3"
           }
         },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.x.x"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true,
           "optional": true
@@ -5613,36 +5110,36 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "version": "1.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "mailcomposer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-4.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mailcomposer/-/mailcomposer-4.0.1.tgz",
       "integrity": "sha1-DhxEsqB890DuF9wUm6AJ8Zyt/rQ=",
       "dev": true,
       "optional": true,
@@ -5652,191 +5149,177 @@
       }
     },
     "mailgun-js": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.7.15.tgz",
-      "integrity": "sha1-7jZqINrGTDwVwD1sGz4O15UlKrs=",
+      "version": "0.18.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mailgun-js/-/mailgun-js-0.18.1.tgz",
+      "integrity": "sha512-lvuMP14u24HS2uBsJEnzSyPMxzU2b99tQsIx1o6QNjqxjk8b3WvR+vq5oG1mjqz/IBYo+5gF+uSoDS0RkMVHmg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "~2.1.2",
-        "debug": "~2.2.0",
-        "form-data": "~2.1.1",
-        "inflection": "~1.10.0",
-        "is-stream": "^1.1.0",
-        "path-proxy": "~1.0.0",
-        "proxy-agent": "~2.0.0",
-        "q": "~1.4.0",
-        "tsscmp": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true,
-          "optional": true
-        },
-        "q": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-          "dev": true,
-          "optional": true
-        }
+        "async": "2.6.1",
+        "debug": "3.1.0",
+        "form-data": "2.3.2",
+        "inflection": "1.12.0",
+        "is-stream": "1.1.0",
+        "path-proxy": "1.0.0",
+        "promisify-call": "2.0.4",
+        "proxy-agent": "3.0.1",
+        "tsscmp": "1.0.6"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
       }
     },
     "md5.js": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      },
-      "dependencies": {
-        "hash-base": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        }
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "mem": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "version": "3.1.10",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "version": "1.36.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-lookup": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mime-lookup/-/mime-lookup-0.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mime-lookup/-/mime-lookup-0.0.2.tgz",
       "integrity": "sha1-o1JdJixC5MraWFmR+FADil1dJB0="
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.20",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.36.0"
       }
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimalistic-assert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+      "version": "1.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5845,7 +5328,7 @@
     },
     "mocha": {
       "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "requires": {
@@ -5863,13 +5346,13 @@
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/commander/-/commander-2.3.0.tgz",
           "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -5878,45 +5361,45 @@
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
           "dev": true
         },
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
           }
         },
         "lru-cache": {
           "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/lru-cache/-/lru-cache-2.7.3.tgz",
           "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "supports-color": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/supports-color/-/supports-color-1.2.0.tgz",
           "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
@@ -5924,82 +5407,102 @@
     },
     "module-deps": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "browser-resolve": "^1.7.0",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "~1.5.0",
-        "defined": "^1.0.0",
-        "detective": "^4.0.0",
-        "duplexer2": "^0.1.2",
-        "inherits": "^2.0.1",
-        "parents": "^1.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.1.3",
-        "stream-combiner2": "^1.1.1",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.0"
+        "JSONStream": "1.3.4",
+        "browser-resolve": "1.11.3",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "defined": "1.0.0",
+        "detective": "4.7.1",
+        "duplexer2": "0.1.4",
+        "inherits": "2.0.3",
+        "parents": "1.0.1",
+        "readable-stream": "2.3.6",
+        "resolve": "1.8.1",
+        "stream-combiner2": "1.1.1",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "http://artifacts.apiture.com/repository/npm-group/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.11.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
     },
     "native-promise-only": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "netmask": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true,
       "optional": true
     },
     "node-fetch": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-readfiles": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/node-readfiles/-/node-readfiles-0.2.0.tgz",
       "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
       "requires": {
-        "es6-promise": "^3.2.1"
+        "es6-promise": "3.3.1"
       },
       "dependencies": {
         "es6-promise": {
           "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/es6-promise/-/es6-promise-3.3.1.tgz",
           "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         }
       }
     },
     "nodemailer": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-2.7.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer/-/nodemailer-2.7.2.tgz",
       "integrity": "sha1-8kLmSa7q45tsftdA73sGHEBNMPk=",
       "dev": true,
       "optional": true,
@@ -6013,29 +5516,22 @@
         "socks": "1.1.9"
       },
       "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true,
-          "optional": true
-        },
         "socks": {
           "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/socks/-/socks-1.1.9.tgz",
           "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
           "dev": true,
           "optional": true,
           "requires": {
-            "ip": "^1.1.2",
-            "smart-buffer": "^1.0.4"
+            "ip": "1.1.5",
+            "smart-buffer": "1.1.15"
           }
         }
       }
     },
     "nodemailer-direct-transport": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz",
       "integrity": "sha1-6W+vuQNYVglH5WkBfZfmBzilCoY=",
       "dev": true,
       "optional": true,
@@ -6046,13 +5542,13 @@
     },
     "nodemailer-fetch": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
       "dev": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
       "requires": {
@@ -6061,7 +5557,7 @@
     },
     "nodemailer-smtp-pool": {
       "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.8.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.8.2.tgz",
       "integrity": "sha1-LrlNbPhXgLG0clzoU7nL1ejajHI=",
       "dev": true,
       "optional": true,
@@ -6073,7 +5569,7 @@
     },
     "nodemailer-smtp-transport": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
       "integrity": "sha1-A9ccdjFPFKx9vHvwM6am0W1n+3c=",
       "dev": true,
       "optional": true,
@@ -6085,102 +5581,141 @@
     },
     "nodemailer-wellknown": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
       "dev": true
     },
     "nomnom": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nomnom/-/nomnom-1.5.2.tgz",
       "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
       "requires": {
-        "colors": "0.5.x",
-        "underscore": "1.1.x"
+        "colors": "0.5.1",
+        "underscore": "1.1.7"
       },
       "dependencies": {
         "underscore": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/underscore/-/underscore-1.1.7.tgz",
           "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA="
         }
       }
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "null-check": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/null-check/-/null-check-1.0.0.tgz",
       "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
       }
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -6189,33 +5724,33 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "ono": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.3.tgz",
-      "integrity": "sha512-7QIxG4UB00H7CR7fhXC/U7VhB5DK9wsYLwaYBui1JmQoXtLkhIBn3fbuk6FgAP+ctWeBsWVTM+R/bThvUZN+ww==",
+      "version": "4.0.7",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ono/-/ono-4.0.7.tgz",
+      "integrity": "sha512-FJiGEETwfSVyOwVTwQZD7XN69FRekvgtlobtvPwtilc7PxIHg3gKUykdNP7E9mC/VTF2cxqKZxUZfNKA3MuQLA==",
       "requires": {
-        "format-util": "^1.0.3"
+        "format-util": "1.0.3"
       }
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -6223,254 +5758,245 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-browserify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "pac-proxy-agent": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-1.1.0.tgz",
-      "integrity": "sha512-QBELCWyLYPgE2Gj+4wUEiMscHrQ8nRPBzYItQNOHWavwBt25ohZHQC4qnd5IszdVVrFbLsQ+dPkm6eqdjJAmwQ==",
+      "version": "2.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
+      "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3",
-        "get-uri": "2",
-        "http-proxy-agent": "1",
-        "https-proxy-agent": "1",
-        "pac-resolver": "~2.0.0",
-        "raw-body": "2",
-        "socks-proxy-agent": "2"
+        "agent-base": "4.2.1",
+        "debug": "3.1.0",
+        "get-uri": "2.0.2",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "pac-resolver": "3.0.0",
+        "raw-body": "2.3.3",
+        "socks-proxy-agent": "3.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "socks-proxy-agent": {
+          "version": "3.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+          "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "agent-base": "4.2.1",
+            "socks": "1.1.10"
           }
         }
       }
     },
     "pac-resolver": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-2.0.0.tgz",
-      "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
+      "version": "3.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pac-resolver/-/pac-resolver-3.0.0.tgz",
+      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "co": "~3.0.6",
-        "degenerator": "~1.0.2",
-        "ip": "1.0.1",
-        "netmask": "~1.0.4",
-        "thunkify": "~2.1.1"
-      },
-      "dependencies": {
-        "co": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
-          "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
-          "dev": true,
-          "optional": true
-        }
+        "co": "4.6.0",
+        "degenerator": "1.0.4",
+        "ip": "1.1.5",
+        "netmask": "1.0.6",
+        "thunkify": "2.1.2"
       }
     },
     "pako": {
       "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parents": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "~0.11.15"
+        "path-platform": "0.11.15"
       }
     },
     "parse-asn1": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "version": "5.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "version": "0.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-loader": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
-      "integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
+      "version": "1.0.8",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-loader/-/path-loader-1.0.8.tgz",
+      "integrity": "sha512-/JQCrTcrteaPB8IHefEAQbmBQReKj51A+yTyc745TBbO4FOySw+/l3Rh0zyad0Nrd87TMROlmFANQwCRsuvN4w==",
       "requires": {
-        "native-promise-only": "^0.8.1",
-        "superagent": "^3.6.3"
+        "native-promise-only": "0.8.1",
+        "superagent": "3.8.3"
       }
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-platform": {
       "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
     "path-proxy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-proxy/-/path-proxy-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-proxy/-/path-proxy-1.0.0.tgz",
       "integrity": "sha1-GOijaFn8nS8aU7SN7hOFQ8Ag3l4=",
       "dev": true,
       "optional": true,
       "requires": {
-        "inflection": "~1.3.0"
+        "inflection": "1.3.8"
       },
       "dependencies": {
         "inflection": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.3.8.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/inflection/-/inflection-1.3.8.tgz",
           "integrity": "sha1-y9Fg2p91sUw8xjV41POWeEvzAU4=",
           "dev": true,
           "optional": true
@@ -6479,7 +6005,7 @@
     },
     "path-to-regexp": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "requires": {
         "isarray": "0.0.1"
@@ -6487,874 +6013,847 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
     "path-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "pbkdf2": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "version": "3.0.16",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pbkdf2/-/pbkdf2-3.0.16.tgz",
+      "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.7",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.88.0",
+        "request-progress": "2.0.1",
+        "which": "1.3.1"
       }
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pluralize": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.1.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pluralize/-/pluralize-1.1.6.tgz",
       "integrity": "sha1-5L9dazayr8IsgB98Nyk2F+C9xW0="
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
-    "proxy-agent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.0.0.tgz",
-      "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
+    "promisify-call": {
+      "version": "2.0.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/promisify-call/-/promisify-call-2.0.4.tgz",
+      "integrity": "sha1-1IwtRWUszM1SgB3ey9UzptS9X7o=",
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3",
-        "http-proxy-agent": "1",
-        "https-proxy-agent": "1",
-        "lru-cache": "~2.6.5",
-        "pac-proxy-agent": "1",
-        "socks-proxy-agent": "2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-          "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
-          "dev": true,
-          "optional": true
-        }
+        "with-callback": "1.0.2"
+      }
+    },
+    "proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/proxy-agent/-/proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-mAZexaz9ZxQhYPWfAjzlrloEjW+JHiBFryE4AJXFDTnaXfmH/FKqC1swTRKuEPbHWz02flQNXFOyDUF7zfEG6A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "lru-cache": "4.1.3",
+        "pac-proxy-agent": "2.0.2",
+        "proxy-from-env": "1.0.0",
+        "socks-proxy-agent": "4.0.1"
       }
     },
     "proxy-from-env": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
     "public-encrypt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "version": "4.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "puppeteer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.3.0.tgz",
-      "integrity": "sha512-wx10aPQPpGJVxdB6yoDSLm9p4rCwARUSLMVV0bx++owuqkvviXKyiFM3EWsywaFmjOKNPXacIjplF7xhHiFP3w==",
+      "version": "1.7.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/puppeteer/-/puppeteer-1.7.0.tgz",
+      "integrity": "sha512-f+1DxKHPqce6CXUBz2eVO2WcATeVeQSOPG9GYaGObEZDCiCEUwG+gogjMsrvn7he2wHTqNVb5p6RUrwmr8XFBA==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
-        "mime": "^1.3.4",
-        "progress": "^2.0.0",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
+        "debug": "3.1.0",
+        "extract-zip": "1.6.7",
+        "https-proxy-agent": "2.2.1",
+        "mime": "2.3.1",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "5.2.2"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+          "dev": true
         },
         "progress": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/progress/-/progress-2.0.0.tgz",
           "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
           "dev": true
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "1.0.0"
+          }
         }
       }
     },
     "q": {
       "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/q/-/q-0.9.7.tgz",
       "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
     },
     "qjobs": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/qjobs/-/qjobs-1.2.0.tgz",
       "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "raml-parser": {
       "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/raml-parser/-/raml-parser-0.8.18.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/raml-parser/-/raml-parser-0.8.18.tgz",
       "integrity": "sha1-CHM3UDT4uKHSDBDjFHtiebM0l6g=",
       "requires": {
-        "got": "~2.4.0",
-        "jju": "~1.2.0",
-        "json-schema-ref-parser": "^3.1.2",
-        "object-assign": "^4.1.0",
-        "pluralize": "~1.1.1",
+        "got": "2.4.0",
+        "jju": "1.2.1",
+        "json-schema-ref-parser": "3.3.1",
+        "object-assign": "4.1.1",
+        "pluralize": "1.1.6",
         "q": "0.9.7",
-        "uritemplate": "~0.3.4"
+        "uritemplate": "0.3.4"
       }
     },
     "raml-to-swagger": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/raml-to-swagger/-/raml-to-swagger-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/raml-to-swagger/-/raml-to-swagger-1.1.0.tgz",
       "integrity": "sha1-jVMLSN3WOE7arEvQUVJv6wXwl2Y=",
       "requires": {
-        "http-status-codes": "^1.0.5",
-        "json-schema-compatibility": "^1.1.0",
-        "jsonpath": "^0.2.5",
-        "lodash": "^4.1.0",
-        "urijs": "^1.17.0"
+        "http-status-codes": "1.3.0",
+        "json-schema-compatibility": "1.1.0",
+        "jsonpath": "0.2.12",
+        "lodash": "4.17.10",
+        "urijs": "1.19.1"
       }
     },
     "randexp": {
       "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/randexp/-/randexp-0.4.9.tgz",
       "integrity": "sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
       "requires": {
-        "drange": "^1.0.0",
-        "ret": "^0.2.0"
-      }
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
-      "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
+        "drange": "1.0.2",
+        "ret": "0.2.2"
       }
     },
     "randombytes": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "safer-buffer": "2.1.2"
           }
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
         }
       }
     },
     "read-all-stream": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/read-all-stream/-/read-all-stream-1.0.2.tgz",
       "integrity": "sha1-03jPTvbiNrGI6kLRNeWxgKiePpI="
     },
     "read-only-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "read-pkg": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       }
     },
     "readable-stream": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "version": "2.3.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "redis": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "dev": true,
       "optional": true,
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.5",
+        "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/redis-commands/-/redis-commands-1.3.5.tgz",
       "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA==",
       "dev": true,
       "optional": true
     },
     "redis-parser": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
       "dev": true,
       "optional": true
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
       "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
       "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "version": "1.1.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.88.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "request-progress": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "^1.0.0"
+        "throttleit": "1.0.0"
       }
     },
     "requestretry": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/requestretry/-/requestretry-1.13.0.tgz",
       "integrity": "sha512-Lmh9qMvnQXADGAQxsXHP4rbgO6pffCfuR8XUBdP9aitJcLQJxhp7YZK4xAVYXnPJ5E52mwrfiKQtKonPL8xsmg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "extend": "^3.0.0",
-        "lodash": "^4.15.0",
-        "request": "^2.74.0",
-        "when": "^3.7.7"
+        "extend": "3.0.2",
+        "lodash": "4.17.10",
+        "request": "2.88.0",
+        "when": "3.7.8"
       }
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.8.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
     },
     "ret": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ret/-/ret-0.2.2.tgz",
       "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "version": "2.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      },
+      "dependencies": {
+        "ret": {
+          "version": "0.1.15",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+          "dev": true
+        }
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.5.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "setprototypeof": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+      "version": "2.4.11",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "~0.0.0",
-        "sha.js": "~2.4.4"
+        "json-stable-stringify": "0.0.1",
+        "sha.js": "2.4.11"
       }
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shell-quote": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "should": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
-      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "version": "13.2.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "requires": {
-        "should-equal": "^2.0.0",
-        "should-format": "^3.0.3",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
+        "should-equal": "2.0.0",
+        "should-format": "3.0.3",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0",
+        "should-util": "1.0.0"
       }
     },
     "should-equal": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/should-equal/-/should-equal-2.0.0.tgz",
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "requires": {
-        "should-type": "^1.4.0"
+        "should-type": "1.4.0"
       }
     },
     "should-format": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/should-format/-/should-format-3.0.3.tgz",
       "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "requires": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0"
       }
     },
     "should-type": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/should-type/-/should-type-1.4.0.tgz",
       "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
     },
     "should-type-adaptors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
       "requires": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
+        "should-type": "1.4.0",
+        "should-util": "1.0.0"
       }
     },
     "should-util": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/should-util/-/should-util-1.0.0.tgz",
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM="
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
     },
     "sinon": {
       "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "util": "0.10.4"
       }
     },
     "sinon-chai": {
       "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sinon-chai/-/sinon-chai-2.14.0.tgz",
       "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
       "dev": true
     },
     "slack-node": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/slack-node/-/slack-node-0.2.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/slack-node/-/slack-node-0.2.0.tgz",
       "integrity": "sha1-3kuN3aqLeT9h29KTgQT9q/N9+jA=",
       "dev": true,
       "optional": true,
       "requires": {
-        "requestretry": "^1.2.2"
+        "requestretry": "1.13.0"
       }
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "smart-buffer": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/smart-buffer/-/smart-buffer-1.1.15.tgz",
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "smtp-connection": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
       "requires": {
@@ -7362,30 +6861,154 @@
         "nodemailer-shared": "1.1.0"
       }
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.x.x"
-      }
-    },
-    "socket.io": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
-      "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "debug": "~2.6.6",
-        "engine.io": "~3.1.0",
-        "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.0.4",
-        "socket.io-parser": "~3.1.1"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "socket.io": {
+      "version": "2.0.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/socket.io/-/socket.io-2.0.4.tgz",
+      "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "engine.io": "3.1.5",
+        "socket.io-adapter": "1.1.1",
+        "socket.io-client": "2.0.4",
+        "socket.io-parser": "3.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -7396,13 +7019,13 @@
     },
     "socket.io-adapter": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
       "dev": true
     },
     "socket.io-client": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/socket.io-client/-/socket.io-client-2.0.4.tgz",
       "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
       "dev": true,
       "requires": {
@@ -7410,20 +7033,20 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.6",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "3.1.3",
         "to-array": "0.1.4"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -7434,19 +7057,19 @@
     },
     "socket.io-parser": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
       "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.3",
         "isarray": "2.0.1"
       },
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -7454,354 +7077,419 @@
     },
     "socks": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/socks/-/socks-1.1.10.tgz",
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "ip": "^1.1.4",
-        "smart-buffer": "^1.0.13"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true
-        }
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
       }
     },
     "socks-proxy-agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
+      "version": "4.0.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "agent-base": "2",
-        "extend": "3",
-        "socks": "~1.1.5"
+        "agent-base": "4.2.1",
+        "socks": "2.2.1"
+      },
+      "dependencies": {
+        "smart-buffer": {
+          "version": "4.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/smart-buffer/-/smart-buffer-4.0.1.tgz",
+          "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==",
+          "dev": true,
+          "optional": true
+        },
+        "socks": {
+          "version": "2.2.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/socks/-/socks-2.2.1.tgz",
+          "integrity": "sha512-0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ip": "1.1.5",
+            "smart-buffer": "4.0.1"
+          }
+        }
       }
     },
     "source-map": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.6.0.tgz",
       "integrity": "sha512-mTozplhTX4tLKIHYji92OTZzVyZvi+Z1qRZDeBvQFI2XUB89wrRoj/xXad3c9NZ1GPJXXRvB+k41PQCPTMC+aA=="
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
     "spdx-correct": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
       "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "static-eval": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/static-eval/-/static-eval-0.2.3.tgz",
       "integrity": "sha1-Aj8XrJ/uQm6niMEuo5IG3Bdfiyo=",
       "requires": {
-        "escodegen": "~0.0.24"
+        "escodegen": "0.0.28"
       },
       "dependencies": {
         "escodegen": {
           "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/escodegen/-/escodegen-0.0.28.tgz",
           "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
           "requires": {
-            "esprima": "~1.0.2",
-            "estraverse": "~1.3.0",
-            "source-map": ">= 0.1.2"
+            "esprima": "1.0.4",
+            "estraverse": "1.3.2",
+            "source-map": "0.6.0"
           }
         },
         "esprima": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
         },
         "estraverse": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/estraverse/-/estraverse-1.3.2.tgz",
           "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
         }
       }
     },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      "version": "1.5.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-http": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
-      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+      "version": "2.8.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "stream-splicer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/stream-splicer/-/stream-splicer-2.0.0.tgz",
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "streamroller": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/streamroller/-/streamroller-0.7.0.tgz",
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "readable-stream": "^2.3.0"
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "mkdirp": "0.5.1",
+        "readable-stream": "2.3.6"
       }
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true,
+      "optional": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "subarg": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "version": "3.8.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.1.1",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.0.5"
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.2",
+        "debug": "3.1.0",
+        "extend": "3.0.2",
+        "form-data": "2.3.2",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6"
       }
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "swagger-converter": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-1.4.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/swagger-converter/-/swagger-converter-1.4.4.tgz",
       "integrity": "sha512-ylYS/Quk3L2A5zGtS5LQFMOtSKTU7Ot8pEAzlG4G/lb7+zC4FnlbD4+CKeQVf+mSGljschOjKHejvtCRyDKbsw==",
       "requires": {
-        "common-prefix": "^1.1.0",
-        "urijs": "^1.16.1"
+        "common-prefix": "1.1.0",
+        "urijs": "1.19.1"
       }
     },
     "swagger-methods": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/swagger-methods/-/swagger-methods-1.0.4.tgz",
       "integrity": "sha512-xrKFLbrZ6VxRsg+M3uJozJtsEpNI/aPfZsOkoEjXw8vhAqdMIqwTYGj1f4dmUgvJvCdZhV5iArgtqXgs403ltg=="
     },
     "swagger-schema-official": {
       "version": "2.0.0-bab6bed",
-      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
       "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
     },
     "swagger2openapi": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-2.9.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/swagger2openapi/-/swagger2openapi-2.9.2.tgz",
       "integrity": "sha512-kav+PP5CPlcLePdTb1kYjLg+ioAnzcm1jCXybFH+3WmFah94+gq4TTT4+y3Y2CumPiPgSm20Z+h52xOkIcPRAw==",
       "requires": {
-        "ajv": "^5.0.1",
-        "call-me-maybe": "^1.0.1",
-        "co": "^4.6.0",
-        "jgexml": "^0.3.8",
-        "js-yaml": "^3.6.1",
-        "node-fetch": "^1.6.3",
-        "node-readfiles": "^0.2.0",
-        "should": "^13.0.1",
-        "yargs": "^9.0.1"
+        "ajv": "5.5.2",
+        "call-me-maybe": "1.0.1",
+        "co": "4.6.0",
+        "jgexml": "0.3.8",
+        "js-yaml": "3.12.0",
+        "node-fetch": "1.7.3",
+        "node-readfiles": "0.2.0",
+        "should": "13.2.3",
+        "yargs": "9.0.1"
       }
     },
     "sway": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sway/-/sway-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/sway/-/sway-1.0.0.tgz",
       "integrity": "sha1-No/8Dpa9hCJu0bmzPWa+V9oE8Jo=",
       "requires": {
-        "debug": "^2.2.0",
-        "js-base64": "^2.1.9",
-        "js-yaml": "^3.5.2",
-        "json-refs": "^2.1.5",
-        "json-schema-faker": "^0.2.8",
-        "lodash": "^4.2.0",
-        "native-promise-only": "^0.8.1",
-        "path-to-regexp": "^1.2.1",
-        "swagger-methods": "^1.0.0",
+        "debug": "2.6.9",
+        "js-base64": "2.4.9",
+        "js-yaml": "3.12.0",
+        "json-refs": "2.1.7",
+        "json-schema-faker": "0.2.16",
+        "lodash": "4.17.10",
+        "native-promise-only": "0.8.1",
+        "path-to-regexp": "1.7.0",
+        "swagger-methods": "1.0.4",
         "swagger-schema-official": "2.0.0-bab6bed",
-        "z-schema": "^3.16.1"
+        "z-schema": "3.23.0"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -7811,229 +7499,371 @@
     },
     "syntax-error": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/syntax-error/-/syntax-error-1.4.0.tgz",
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "^1.2.0"
+        "acorn-node": "1.5.2"
       }
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "thunkify": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
       "dev": true,
       "optional": true
     },
     "timed-out": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/timed-out/-/timed-out-2.0.0.tgz",
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "~0.11.0"
+        "process": "0.11.10"
       }
     },
     "timespan": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/timespan/-/timespan-2.3.0.tgz",
       "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
       "dev": true,
       "optional": true
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "to-iso-string": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-iso-string/-/to-iso-string-0.0.2.tgz",
       "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       }
     },
     "traverse": {
       "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
+      "version": "1.0.6",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
       "dev": true,
       "optional": true
     },
     "tty-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.20"
       }
     },
     "type-of-is": {
       "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/type-of-is/-/type-of-is-3.5.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/type-of-is/-/type-of-is-3.5.1.tgz",
       "integrity": "sha1-7sL8ibgo2/mQDrZBbu4w9P4PzTE="
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "ultron": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "umd": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
-      "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
+      "version": "3.0.3",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
       "dev": true
+    },
+    "undeclared-identifiers": {
+      "version": "1.1.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
+      "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "1.5.2",
+        "get-assigned-identifiers": "1.2.0",
+        "simple-concat": "1.0.0",
+        "xtend": "4.0.1"
+      }
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "http://artifacts.apiture.com/repository/npm-group/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
     "uri-js": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/uri-js/-/uri-js-3.0.2.tgz",
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+          "version": "2.1.1",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },
     "urijs": {
       "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/urijs/-/urijs-1.19.1.tgz",
       "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "uritemplate": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/uritemplate/-/uritemplate-0.3.4.tgz",
       "integrity": "sha1-BdCoU/+8iw9Jqj1NKtd3sNHuBww="
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -8043,97 +7873,95 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
       }
     },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
     "useragent": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/useragent/-/useragent-2.2.1.tgz",
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.x",
-        "tmp": "0.0.x"
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/lru-cache/-/lru-cache-2.2.4.tgz",
           "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
           "dev": true
         }
       }
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.10.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "uws": {
       "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/uws/-/uws-9.14.0.tgz",
       "integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
       "dev": true,
       "optional": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validator": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+      "version": "10.7.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/validator/-/validator-10.7.1.tgz",
+      "integrity": "sha512-tbB5JrTczfeHKLw3PnFRzGFlF1xUAwSgXEDb66EuX1ffCirspYpDEZo3Vc9j38gPdL4JKrDc5UPFfgYiw1IWRQ=="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -8142,169 +7970,176 @@
     },
     "void-elements": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
     "when": {
       "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/when/-/when-3.7.8.tgz",
       "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=",
       "dev": true,
       "optional": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "with-callback": {
+      "version": "1.0.2",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/with-callback/-/with-callback-1.0.2.tgz",
+      "integrity": "sha1-oJYpuakgAo1yFAT7Q1vc/1yRvCE=",
+      "dev": true,
+      "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true,
       "optional": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://artifacts.apiture.com/repository/npm-group/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
       }
     },
     "xml2js": {
       "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
       "dev": true
     },
     "xregexp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
       "dev": true,
       "optional": true
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/yargs/-/yargs-9.0.1.tgz",
       "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
       "requires": {
-        "camelcase": "^4.1.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "read-pkg-up": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^7.0.0"
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
       }
     },
     "yargs-parser": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     },
     "z-schema": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
-      "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
+      "version": "3.23.0",
+      "resolved": "http://artifacts.apiture.com/repository/npm-group/z-schema/-/z-schema-3.23.0.tgz",
+      "integrity": "sha512-D8XV0BiHuQbWNEgu68RpjFZJ0C7jt+WYoszXKOohe54TdoTTauUvBQx+lsYCdalGIjGTFdQs5dxKvCUonUERzQ==",
       "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^9.0.0"
+        "commander": "2.17.1",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "validator": "10.7.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-spec-converter",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "engines": {
     "node": ">=6.0.0"
   },
@@ -61,6 +61,7 @@
     "composite-error": "^0.1.1",
     "deep-sort-object": "^1.0.2",
     "drafter.js": "^2.6.6",
+    "fsevents": "^1.2.4",
     "google-discovery-to-swagger": "^2.0.0",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "composite-error": "^0.1.1",
     "deep-sort-object": "^1.0.2",
     "drafter.js": "^2.6.6",
-    "fsevents": "^1.2.4",
     "google-discovery-to-swagger": "^2.0.0",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.10",
@@ -92,5 +91,8 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
     "puppeteer": "^1.3.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.2.4"
   }
 }


### PR DESCRIPTION
add `'components'`, `'servers'`, and `'openapi'` so `--order openapi` works with `--to openapi_3`; fixes #172 

Note: I could not get the build to run cleanly to to native fsevents when I tried `npm install`. Hence, I could also not test with `WRITE_GOLDEN=true npm test` even at master in a clean repo without my changes. but other manual tests worked OK with this changes.