### PR TITLE
Ensure that 'name' property of request body is unique 

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -124,7 +124,7 @@ Converter.prototype.convertParameters = function(operation) {
     operation.parameters = operation.parameters || [];
     if (operation.requestBody) {
         param = this.resolveReference(this.spec, operation.requestBody);
-        param.name = 'body';
+        param.name = `${operation.operationId}-body`;
         content = param.content;
         if (content) {
             contentKey = getSupportedMimeTypes(content)[0];

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -107,24 +107,30 @@ Converter.prototype.convertInfos = function() {
 
 Converter.prototype.convertOperations = function() {
     var path, pathObject, method, operation;
+    var bodyNameExists = { data: false };
     for (path in this.spec.paths) {
         pathObject = this.spec.paths[path] = this.resolveReference(this.spec, this.spec.paths[path]);
         for (method in pathObject) {
             if (HTTP_METHODS.indexOf(method) >= 0) {
                 operation = pathObject[method] = this.resolveReference(this.spec, pathObject[method]);
-                this.convertParameters(operation);
+                this.convertParameters(operation, bodyNameExists);
                 this.convertResponses(operation);
             }
         }
     }
 }
 
-Converter.prototype.convertParameters = function(operation) {
+Converter.prototype.convertParameters = function(operation, bodyNameExists) {
     var content, param, contentKey;
     operation.parameters = operation.parameters || [];
     if (operation.requestBody) {
         param = this.resolveReference(this.spec, operation.requestBody);
-        param.name = `${operation.operationId}-body`;
+        if (bodyNameExists.data) {
+            param.name = `${operation.operationId}-body`;
+        } else {
+            param.name = 'body';
+            bodyNameExists.data = true;
+        }
         content = param.content;
         if (content) {
             contentKey = getSupportedMimeTypes(content)[0];

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -320,7 +320,7 @@
         "parameters": [
           {
             "in": "formData",
-            "name": "body",
+            "name": "uploadFile-body",
             "type": "file"
           }
         ],
@@ -440,7 +440,7 @@
           {
             "description": "Pet object that needs to be added to the store",
             "in": "body",
-            "name": "body",
+            "name": "partialUpdate-body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Pet"
@@ -543,7 +543,7 @@
           {
             "description": "order placed for purchasing the pet",
             "in": "body",
-            "name": "body",
+            "name": "placeOrder-body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Order"
@@ -663,7 +663,7 @@
           {
             "description": "Created user object",
             "in": "body",
-            "name": "body",
+            "name": "createUser-body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/User"
@@ -703,7 +703,7 @@
           {
             "description": "List of user object",
             "in": "body",
-            "name": "body",
+            "name": "createUsersWithListInput-body",
             "required": true,
             "schema": {
               "items": {
@@ -908,7 +908,7 @@
           {
             "description": "Updated user object",
             "in": "body",
-            "name": "body",
+            "name": "updateUser-body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/User"
@@ -1031,7 +1031,7 @@
       "UserArray": {
         "description": "List of user object",
         "in": "body",
-        "name": "body",
+        "name": "createUsersWithListInput-body",
         "required": true,
         "schema": {
           "items": {


### PR DESCRIPTION
Appending `operationId` to the name ensures that the `name` property of request body is unique. Having same name for all request bodies in Swagger v2.0 might result in errors in some systems e.g. Azure API Management