### PR TITLE
WADL reader fixes, duplicate params and missing info object

### DIFF
--- a/lib/formats/wadl.js
+++ b/lib/formats/wadl.js
@@ -175,7 +175,8 @@ function convertToSwagger(wadl) {
 
     var wadlRequest = unwrapArray(wadlMethod.request);
     if (wadlRequest)
-      method.parameters = _.map(wadlRequest.param, convertParameter);
+      method.parameters = _.uniqBy(_.map(wadlRequest.param, convertParameter),function(e){
+      return e.name + e.in });
 
     _.extend(method, convertDoc(wadlMethod.doc));
 
@@ -247,7 +248,8 @@ function convertToSwagger(wadl) {
     assert(!_.has(wadlResource, 'resource_type'));
 
     var resource = {};
-    var commonParameters = _.map(wadlResource.param, convertParameter);
+    var commonParameters = _.uniqBy(_.map(wadlResource.param, convertParameter),function(e){
+    return e.name + e.in });
 
     _.each(wadlResource.method, function(wadlMethod) {
       var httpMethod = wadlMethod.$.name.toLowerCase();
@@ -262,7 +264,8 @@ function convertToSwagger(wadl) {
     _.each(wadlResource.resource, function (wadlSubResource) {
       var subPaths = convertResource(wadlSubResource);
       subPaths = _.mapKeys(subPaths, function (subPath, path) {
-        subPath.parameters = commonParameters.concat(subPath.parameters);
+        subPath.parameters = _.uniqBy(commonParameters.concat(subPath.parameters),function(e){
+        return e.name + e.id });
         return Util.joinPath(resourcePath, convertPath(path));
       });
       mergePaths(paths, subPaths);
@@ -284,10 +287,16 @@ function convertToSwagger(wadl) {
   }
 
   var root = unwrapArray(wadl.application.resources);
+  var title = wadl.application.doc && wadl.application.doc[1] && wadl.application.doc[1].$ ?
+    wadl.application.doc[1].$.title : "";
 
   var baseUrl = URI(root.$.base);
   var swagger = {
     swagger: '2.0',
+    info: {
+      title: title,
+      version: ""
+    },
     host:  baseUrl.host() || undefined,
     basePath: baseUrl.pathname() || undefined,
     schemes: baseUrl.protocol() ? [baseUrl.protocol()] : undefined,

--- a/test/output/swagger_2/OpenStack_example.json
+++ b/test/output/swagger_2/OpenStack_example.json
@@ -2,8 +2,8 @@
   "basePath": "/",
   "host": "localhost:35357",
   "info": {
-    "title": "< An API title here >",
-    "version": "< An API version here >"
+    "title": "",
+    "version": ""
   },
   "paths": {
     "/": {

--- a/test/output/swagger_2/facebook.json
+++ b/test/output/swagger_2/facebook.json
@@ -2,8 +2,8 @@
   "basePath": "/",
   "host": "graph.facebook.com",
   "info": {
-    "title": "< An API title here >",
-    "version": "< An API version here >"
+    "title": "",
+    "version": ""
   },
   "paths": {
     "/search": {

--- a/test/output/swagger_2/regex_paths.json
+++ b/test/output/swagger_2/regex_paths.json
@@ -2,8 +2,8 @@
   "basePath": "/resources/v1/",
   "host": "localhost:8080",
   "info": {
-    "title": "< An API title here >",
-    "version": "< An API version here >"
+    "title": "",
+    "version": ""
   },
   "paths": {
     "/{sessionId}": {

--- a/test/output/swagger_2/sample_wadl.json
+++ b/test/output/swagger_2/sample_wadl.json
@@ -2,8 +2,8 @@
   "basePath": "/resources/v1/",
   "host": "localhost:8080",
   "info": {
-    "title": "< An API title here >",
-    "version": "< An API version here >"
+    "title": "",
+    "version": ""
   },
   "paths": {
     "/foo1": {


### PR DESCRIPTION
Back in April in https://github.com/APIs-guru/openapi-directory/issues/393 I noted that the WADL converter did not de-duplicate parameters and didn't include an `info` object. This PR aims to fix this. I wasn't totally sure about the best way to populate `info.title` and `info.version` but I went with what the test harness seemed to be doing.