### PR TITLE
Disable buildTagsFromPaths for Swagger 1

### DIFF
--- a/bin/api-spec-converter
+++ b/bin/api-spec-converter
@@ -7,6 +7,14 @@ var Program = require('commander');
 var Package = require(__dirname + '/../package.json');
 var Converter = require('..');
 
+function keyValue (keyvalue, result) {
+  const pair = keyvalue.split('=', 2);
+  const key = pair[0];
+  const value = JSON.parse(pair[1]);
+  result[key] = value;
+  return result;
+}
+
 Program
   .version(Package.version)
   .description('Convert API descriptions between popular formats.\n\n  ' +
@@ -19,6 +27,7 @@ Program
   .option('-o, --order [sortOrder]', 'Specifies top fields ordering: alpha or default openapi')
   .option('-c, --check', 'Check if result is valid spec')
   .option('-d, --dummy', 'Fill missing required fields with dummy data')
+  .option('--passthrough <keyvalue>', 'Pass an option to the underlying converter', keyValue, {})
   .arguments('<URL|filename>')
   .action(main)
   .parse(process.argv);
@@ -29,11 +38,11 @@ function main(url, options) {
 
   if (!options.to)
     options.to = options.from;
-
   Converter.convert({
     source: url,
     from: options.from,
-    to: options.to
+    to: options.to,
+    passthrough: options.passthrough
   }).then(function (spec) {
     console.log(spec.stringify({syntax: options.syntax, order: options.order}))
     if (!options.check)

--- a/index.js
+++ b/index.js
@@ -30,6 +30,6 @@ Converter.getFormatName = function (name, version) {
 
 Converter.convert = function(options, callback) {
   return Converter.getSpec(options.source, options.from)
-    .then(fromSpec => fromSpec.convertTo(options.to))
+    .then(fromSpec => fromSpec.convertTo(options.to, options.passthrough))
     .asCallback(callback);
 }

--- a/lib/base_format.js
+++ b/lib/base_format.js
@@ -153,7 +153,7 @@ BaseFormat.prototype.resolveResources = function(source) {
     });
 }
 
-BaseFormat.prototype.convertTo = function(format, callback) {
+BaseFormat.prototype.convertTo = function(format, passthrough, callback) {
   return Promise.try(() => {
     if (format === this.format)
       return Promise.resolve(this);
@@ -162,7 +162,7 @@ BaseFormat.prototype.convertTo = function(format, callback) {
     if (!convert)
       throw Error(`Unable to convert from ${this.format} to ${format}`);
 
-    return convert(this)
+    return convert(this, passthrough)
     .then(spec => {
       spec = new Formats[format](spec);
       spec.fixSpec();
@@ -174,11 +174,11 @@ BaseFormat.prototype.convertTo = function(format, callback) {
   }).asCallback(callback);
 }
 
-BaseFormat.prototype.convertTransitive = function(intermediaries) {
+BaseFormat.prototype.convertTransitive = function(intermediaries, passthrough) {
   let prom = Promise.resolve(this);
   intermediaries.forEach(intermediary => {
     prom = prom.then(spec => {
-      return spec.convertTo(intermediary);
+      return spec.convertTo(intermediary, passthrough);
     })
   });
   return prom.then(spec => spec.spec);

--- a/lib/formats/swagger_1.js
+++ b/lib/formats/swagger_1.js
@@ -19,7 +19,7 @@ var Swagger1 = module.exports = function() {
     var swagger2 = SwaggerConverter.convert(
       swagger1.spec,
       swagger1.subResources,
-      {buildTagsFromPaths: true}
+      {buildTagsFromPaths: false}
     );
 
     if (swagger2.info.title === 'Title was not specified')

--- a/lib/formats/swagger_1.js
+++ b/lib/formats/swagger_1.js
@@ -15,11 +15,14 @@ var Swagger1 = module.exports = function() {
   Swagger1.super_.apply(this, arguments);
   this.format = 'swagger_1';
 
-  this.converters.swagger_2 = Promise.method(swagger1 => {
+  this.converters.swagger_2 = Promise.method((swagger1, passthrough) => {
     var swagger2 = SwaggerConverter.convert(
       swagger1.spec,
       swagger1.subResources,
-      {buildTagsFromPaths: false}
+      {buildTagsFromPaths: (passthrough && passthrough.buildTagsFromPaths) === undefined
+        ? true
+        : passthrough.buildTagsFromPaths
+      }
     );
 
     if (swagger2.info.title === 'Title was not specified')

--- a/lib/formats/swagger_1.js
+++ b/lib/formats/swagger_1.js
@@ -28,7 +28,7 @@ var Swagger1 = module.exports = function() {
   });
 
   this.converters.openapi_3 =
-    Promise.method(swagger1 => this.convertTransitive(['swagger_2', 'openapi_3']));
+    Promise.method((swagger1, passthrough) => this.convertTransitive(['swagger_2', 'openapi_3'], passthrough));
 }
 
 Inherits(Swagger1, BaseFormat);

--- a/lib/formats/swagger_1.js
+++ b/lib/formats/swagger_1.js
@@ -16,13 +16,12 @@ var Swagger1 = module.exports = function() {
   this.format = 'swagger_1';
 
   this.converters.swagger_2 = Promise.method((swagger1, passthrough) => {
+    passthrough = passthrough || {};
+    passthrough.buildTagsFromPaths = passthrough.buildTagsFromPaths !== false;
     var swagger2 = SwaggerConverter.convert(
       swagger1.spec,
       swagger1.subResources,
-      {buildTagsFromPaths: (passthrough && passthrough.buildTagsFromPaths) === undefined
-        ? true
-        : passthrough.buildTagsFromPaths
-      }
+      passthrough
     );
 
     if (swagger2.info.title === 'Title was not specified')


### PR DESCRIPTION
Currently `buildTagsFromPaths` is hard-coded to be `true`.

The paths are not a good way to distinguish the operations from each-other. It is better to let the developer decide on the tags that need to be used.

In addition, the paths contain characters that are incompatible (like `/`) that are converted to `__`. This does not look very good.

Removing these tags after the fact can be frustrating, because there can be overlap between intended tags and the ones generated by api-spec-converter.

Related https://github.com/LucyBot-Inc/api-spec-converter/issues/174