### PR TITLE
swagger-converter: 1.4.4 -> 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7595,9 +7595,9 @@
       "dev": true
     },
     "swagger-converter": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-1.4.4.tgz",
-      "integrity": "sha512-ylYS/Quk3L2A5zGtS5LQFMOtSKTU7Ot8pEAzlG4G/lb7+zC4FnlbD4+CKeQVf+mSGljschOjKHejvtCRyDKbsw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-1.5.1.tgz",
+      "integrity": "sha512-u98/Gt+fAnS95WoUDgWuOiN8MymrNCUdcLoD4Q6szy4nAj9BPCVRzwvJauqqj7+jKcB1ZEKf9vacQKSXEr3OBw==",
       "requires": {
         "common-prefix": "^1.1.0",
         "urijs": "^1.16.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "raml-to-swagger": "^1.1.0",
     "request": "^2.88.0",
     "source-map": "0.6.0",
-    "swagger-converter": "^1.4.4",
+    "swagger-converter": "^1.5.1",
     "swagger2openapi": "2.9.2",
     "sway": "^2.0.5",
     "traverse": "^0.6.6",


### PR DESCRIPTION
`swagger-converter` has been updated. The new version has support for converting custom `x-` properties in operations, whereas before this patch such properties would be skipped. With this PR custom properties will now show up in the Swagger 2.x specification as well when converting `swagger_1` using api-spec-converter.