### PR TITLE
Improve body parameter for openapi_3 to swagger_2 conversion

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -136,7 +136,7 @@ Converter.prototype.convertOperationParameters = function(operation) {
 
             if (contentKey === SUPPORTED_MIME_TYPES.APPLICATION_X_WWW_URLENCODED
                 || contentKey === SUPPORTED_MIME_TYPES.MULTIPART_FORM_DATA) {
-                operation.consumes = [contentKey];
+                operation.consumes = mediaTypes;
                 param.in = 'formData';
                 param.schema = content[contentKey].schema;
                 param.schema = this.resolveReference(this.spec, param.schema);
@@ -150,8 +150,8 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 } else {
                     operation.parameters.push(param);
                 }
-            } else if (isJsonMimeType(contentKey)) {
-                operation.consumes = [contentKey];
+            } else if (contentKey) {
+                operation.consumes = mediaTypes;
                 param.in = 'body';
                 param.schema = content[contentKey].schema;
                 operation.parameters.push(param);

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -7,8 +7,7 @@ var HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 
 var APPLICATION_JSON_REGEX = /^(application\/json|[^;\/ \t]+\/[^;\/ \t]+[+]json)[ \t]*(;.*)?$/;
 var SUPPORTED_MIME_TYPES = {
     APPLICATION_X_WWW_URLENCODED: 'application/x-www-form-urlencoded',
-    MULTIPART_FORM_DATA: 'multipart/form-data',
-    APPLICATION_OCTET_STREAM: 'application/octet-stream'
+    MULTIPART_FORM_DATA: 'multipart/form-data'
 };
 
 var npath = require('path');
@@ -122,13 +121,16 @@ Converter.prototype.convertOperations = function() {
 }
 
 Converter.prototype.convertOperationParameters = function(operation) {
-    var content, param, contentKey;
+    var content, param, contentKey, mediaRanges, mediaTypes;
     operation.parameters = operation.parameters || [];
     if (operation.requestBody) {
         param = this.resolveReference(this.spec, operation.requestBody);
         param.name = 'body';
         content = param.content;
         if (content) {
+            mediaRanges = Object.keys(content)
+                .filter(mediaRange => mediaRange.indexOf('/') > 0);
+            mediaTypes = mediaRanges.filter(range => range.indexOf('*') < 0);
             contentKey = getSupportedMimeTypes(content)[0];
             delete param.content;
 
@@ -148,23 +150,21 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 } else {
                     operation.parameters.push(param);
                 }
-            } else if (contentKey === SUPPORTED_MIME_TYPES.APPLICATION_OCTET_STREAM) {
-                operation.consumes = [contentKey];
-                param.in = 'body';
-                param.name = param.name || 'file';
-                delete param.type;
-                param.schema = content[contentKey].schema || {
-                    type: 'string',
-                    format: 'binary'
-                };
-                operation.parameters.push(param);
             } else if (isJsonMimeType(contentKey)) {
                 operation.consumes = [contentKey];
                 param.in = 'body';
                 param.schema = content[contentKey].schema;
                 operation.parameters.push(param);
-            } else {
-                console.warn('unsupported request body media type', operation.operationId, content);
+            } else if (mediaRanges) {
+                operation.consumes = mediaTypes || ['application/octet-stream'];
+                param.in = 'body';
+                param.name = param.name || 'file';
+                delete param.type;
+                param.schema = content[mediaRanges[0]].schema || {
+                    type: 'string',
+                    format: 'binary'
+                };
+                operation.parameters.push(param);
             }
         }
         delete operation.requestBody;

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -150,10 +150,13 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 }
             } else if (contentKey === SUPPORTED_MIME_TYPES.APPLICATION_OCTET_STREAM) {
                 operation.consumes = [contentKey];
-                param.in = 'formData';
-                param.type = 'file';
+                param.in = 'body';
                 param.name = param.name || 'file';
-                delete param.schema;
+                delete param.type;
+                param.schema = content[contentKey].schema || {
+                    type: 'string',
+                    format: 'binary'
+                };
                 operation.parameters.push(param);
             } else if (isJsonMimeType(contentKey)) {
                 operation.consumes = [contentKey];
@@ -180,8 +183,8 @@ Converter.prototype.convertParameters = function(obj) {
 
     (obj.parameters || []).forEach((param, i) => {
         param = obj.parameters[i] = this.resolveReference(this.spec, param);
-        this.copySchemaProperties(param, SCHEMA_PROPERTIES);
         if (param.in !== 'body') {
+            this.copySchemaProperties(param, SCHEMA_PROPERTIES);
             this.copySchemaProperties(param, ARRAY_PROPERTIES);
             delete param.schema;
             delete param.allowReserved;

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -432,12 +432,56 @@
         ]
       }
     },
-    "/pet/uploadImage": {
+    "/pet/uploadFile": {
       "post": {
         "operationId": "uploadFile",
         "requestBody": {
           "content": {
             "application/octet-stream": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "No response was specified"
+          }
+        },
+        "security": [
+          {
+            "oauth2_accessCode": [
+              "write:pets",
+              "read:pets"
+            ]
+          },
+          {
+            "oauth2_implicit": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "summary": "uploads a file",
+        "tags": [
+          "pet"
+        ]
+      }
+    },
+    "/pet/uploadImage": {
+      "post": {
+        "operationId": "uploadImage",
+        "requestBody": {
+          "content": {
+            "image/jpeg": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            },
+            "image/png": {
               "schema": {
                 "format": "binary",
                 "type": "string"

--- a/test/output/openapi_3/petstore_from_oas3.json
+++ b/test/output/openapi_3/petstore_from_oas3.json
@@ -404,12 +404,56 @@
         ]
       }
     },
-    "/pet/uploadImage": {
+    "/pet/uploadFile": {
       "post": {
         "operationId": "uploadFile",
         "requestBody": {
           "content": {
             "application/octet-stream": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "No response was specified"
+          }
+        },
+        "security": [
+          {
+            "oauth2_accessCode": [
+              "write:pets",
+              "read:pets"
+            ]
+          },
+          {
+            "oauth2_implicit": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "summary": "uploads a file",
+        "tags": [
+          "pet"
+        ]
+      }
+    },
+    "/pet/uploadImage": {
+      "post": {
+        "operationId": "uploadImage",
+        "requestBody": {
+          "content": {
+            "image/jpeg": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            },
+            "image/png": {
               "schema": {
                 "format": "binary",
                 "type": "string"

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -311,12 +311,54 @@
         ]
       }
     },
-    "/pet/uploadImage": {
+    "/pet/uploadFile": {
       "post": {
         "consumes": [
           "application/octet-stream"
         ],
         "operationId": "uploadFile",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "No response was specified"
+          }
+        },
+        "security": [
+          {
+            "oauth2_accessCode": [
+              "write:pets",
+              "read:pets"
+            ]
+          },
+          {
+            "oauth2_implicit": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "summary": "uploads a file",
+        "tags": [
+          "pet"
+        ]
+      }
+    },
+    "/pet/uploadImage": {
+      "post": {
+        "consumes": [
+          "image/jpeg",
+          "image/png"
+        ],
+        "operationId": "uploadImage",
         "parameters": [
           {
             "in": "body",

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -319,9 +319,12 @@
         "operationId": "uploadFile",
         "parameters": [
           {
-            "in": "formData",
+            "in": "body",
             "name": "body",
-            "type": "file"
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -471,6 +471,7 @@
       },
       "patch": {
         "consumes": [
+          "application/xml",
           "application/json"
         ],
         "operationId": "partialUpdate",


### PR DESCRIPTION
Currently api-spec-converter creates an invalid Swagger 2 spec for operations with a non-JSON, non-form-data body type.  For example, an OAS v3 spec using the example `requestBody` from the [Considerations for File Uploads section of OAS3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#considerations-for-file-uploads):

```yaml
requestBody:
  content:
    application/octet-stream:
      schema:
        type: string
        format: binary
```

is converted to:

```yaml
consumes:
  - application/octet-stream
parameters:
  - in: formData
    name: body
    type: file
responses:
  '204':
    description: Success
operationId: uploadFile
```

which is invalid because "if type is `file`, the consumes MUST be either `multipart/form-data`, `application/x-www-form-urlencoded` or both" according to [OAS2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-7).

This PR preserves the schema from the OAS3 spec, if present, or uses `type: "string"` with `format: "binary"` (as recommended in https://github.com/OAI/OpenAPI-Specification/issues/326#issuecomment-126710570) and does not copy the non-schema properties from `schema` to `parameter` which would be invalid for `in: "body"`.

It also adds support for other non-JSON, non-form-data body types in the same manner as `application/octet-stream` (instead of logging `unsupported request body media type`) and preserves all media types from `content` in `consumes` instead of only the first supported type.  If either of these changes warrants separate consideration, I can split them into separate pull requests.

Thanks for considering,
Kevin