### PR TITLE
Improve discriminator conversion for openapi_3 to swagger_2

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -282,7 +282,6 @@ Converter.prototype.convertResponses = function(operation) {
 
 Converter.prototype.convertSchemas = function() {
     this.spec.definitions = this.spec.components.schemas;
-    delete this.spec.components.schemas;
 
     for (var defName in this.spec.definitions) {
         var def = this.spec.definitions[defName];
@@ -291,7 +290,37 @@ Converter.prototype.convertSchemas = function() {
         }
 
         if (def.discriminator) {
+            if (def.discriminator.mapping) {
+                this.convertDiscriminatorMapping(def.discriminator.mapping);
+            }
+
             def.discriminator = def.discriminator.propertyName;
+        }
+    }
+
+    delete this.spec.components.schemas;
+}
+
+Converter.prototype.convertDiscriminatorMapping = function(mapping) {
+    for (const payload in mapping) {
+        const schemaNameOrRef = mapping[payload];
+        if (typeof schemaNameOrRef !== 'string') {
+            console.warn(`Ignoring ${schemaNameOrRef} for ${payload} in discriminator.mapping.`);
+            continue;
+        }
+
+        const schema = this.resolveReference(this.spec, {$ref: schemaNameOrRef})
+            || this.resolveReference(this.spec, {$ref: `#/components/schemas/${schemaNameOrRef}`});
+        if (schema) {
+            // Swagger Codegen + OpenAPI Generator extension
+            // https://github.com/swagger-api/swagger-codegen/pull/4252
+            schema['x-discriminator-value'] = payload;
+
+            // AutoRest extension
+            // https://github.com/Azure/autorest/pull/474
+            schema['x-ms-discriminator-value'] = payload;
+        } else {
+            console.warn(`Unable to resolve ${schemaNameOrRef} for ${payload} in discriminator.mapping.`);
         }
     }
 }

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -289,6 +289,10 @@ Converter.prototype.convertSchemas = function() {
         if (def.oneOf) {
             delete def.oneOf;
         }
+
+        if (def.discriminator) {
+            def.discriminator = def.discriminator.propertyName;
+        }
     }
 }
 

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -42,7 +42,10 @@
     "schemas": {
       "Animal": {
         "discriminator": {
-          "propertyName": "type"
+          "propertyName": "type",
+          "mapping": {
+            "Feline": "#/components/schemas/Cat"
+          }
         },
         "properties": {
           "id": {

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -33,7 +33,9 @@
         {
           "$ref": "#/definitions/Animal"
         }
-      ]
+      ],
+      "x-discriminator-value": "Feline",
+      "x-ms-discriminator-value": "Feline"
     },
     "Category": {
       "properties": {

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -2,9 +2,7 @@
   "basePath": "/api",
   "definitions": {
     "Animal": {
-      "discriminator": {
-        "propertyName": "type"
-      },
+      "discriminator": "type",
       "properties": {
         "id": {
           "type": "integer"


### PR DESCRIPTION
In OpenAPI v3, the `discriminator` property is a [Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminatorObject) while in Swagger 2 it is [a string value](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema-object).  This pull request adds a conversion from `.discriminator.propertyName` to `.discriminator` and from `discriminator.mapping` to `.x-discriminator-value` ([for Swagger Codegen + OpenAPI Generator](https://github.com/swagger-api/swagger-codegen/pull/4252)) and `.x-ms-discriminator-value` ([for AutoRest](https://github.com/Azure/autorest/pull/474)) on the discriminated schema objects.

Thanks for considering,
Kevin