### PR TITLE
openapi_3 to 2: Convert multiple response types

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -234,33 +234,43 @@ Converter.prototype.copySchemaProperties = function(obj, props) {
 }
 
 Converter.prototype.convertResponses = function(operation) {
-    var code, content, contentType, response, resolved, headers;
+    var anySchema, code, content, jsonSchema, mediaRange, mediaType, response, resolved, headers;
     for (code in operation.responses) {
-        content = false;
-        contentType = 'application/json';
         response = operation.responses[code] = this.resolveReference(this.spec, operation.responses[code]);
         if (response.content) {
-            if (response.content[contentType]) {
-                content = response.content[contentType];
+            anySchema = jsonSchema = null;
+            for (mediaRange in response.content) {
+                // produces and examples only allow media types, not ranges
+                // use application/octet-stream as a catch-all type
+                mediaType = mediaRange.indexOf('*') < 0 ? mediaRange
+                    : 'application/octet-stream';
+                if (!operation.produces) {
+                    operation.produces = [mediaType];
+                } else if (operation.produces.indexOf(mediaType) < 0) {
+                    operation.produces.push(mediaType);
+                }
+
+                content = response.content[mediaRange];
+
+                anySchema = anySchema || content.schema;
+                if (!jsonSchema && isJsonMimeType(mediaType)) {
+                    jsonSchema = content.schema;
+                }
+
+                if (content.example) {
+                    response.examples = response.examples || {};
+                    response.examples[mediaType] = content.example;
+                }
             }
-            if (!content) {
-                contentType = Object.keys(response.content)[0];
-                content = response.content[contentType];
-            }
-        }
-        if (content) {
-            operation.produces = operation.produces || []
-            if (!operation.produces.includes(contentType)) {
-              operation.produces.push(contentType);
-            }
-            response.schema = content.schema;
-            resolved = this.resolveReference(this.spec, response.schema);
-            if (resolved && response.schema.$ref && !response.schema.$ref.startsWith('#')) {
-                response.schema = resolved;
-            }
-            if (content.example) {
-                response.examples = {};
-                response.examples[contentType] = content.example;
+
+            if (anySchema) {
+                response.schema = jsonSchema || anySchema;
+                resolved = this.resolveReference(this.spec, response.schema);
+                if (resolved
+                    && response.schema.$ref
+                    && !response.schema.$ref.startsWith('#')) {
+                    response.schema = resolved;
+                }
             }
         }
 

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -248,7 +248,10 @@
           }
         ],
         "produces": [
-          "application/json"
+          "application/json",
+          "application/xml",
+          "text/html",
+          "text/plain"
         ],
         "responses": {
           "200": {
@@ -289,7 +292,10 @@
           }
         ],
         "produces": [
-          "application/json"
+          "application/json",
+          "application/xml",
+          "text/html",
+          "text/plain"
         ],
         "responses": {
           "200": {
@@ -448,7 +454,10 @@
           }
         ],
         "produces": [
-          "application/json"
+          "application/json",
+          "application/xml",
+          "text/html",
+          "text/plain"
         ],
         "responses": {
           "200": {
@@ -494,7 +503,8 @@
           }
         ],
         "produces": [
-          "application/json"
+          "application/json",
+          "application/xml"
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
In OAS v3, the content property of the [Response Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject) maps any number of media ranges to [Media Type Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject).  The current implementation would only copy `application/json` (with fallback to the first media range).  This would lose information about operations which can return multiple types and produce an invalid specification for content starting with a media range (since ranges are not allowed in Swagger 2).

This pull request includes all types from `content` in `produces` and `examples`, mapping ranges to `application/octet-stream` as a generic catch-all type.  Since Swagger 2 only supports a single schema, the first schema for a JSON type is used, with fallback to the first of any type.

Thanks for considering,
Kevin