### PR TITLE
fix: preserve nulls in conversions, fixes #210

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -76,7 +76,7 @@ module.exports.getSourceType = function (source) {
 
 module.exports.removeNonValues = function (obj) {
   traverse(obj).forEach(function (value) {
-    if (value === undefined || value === null)
+    if (value === undefined)
       this.remove();
   });
 }


### PR DESCRIPTION
This fix means `null` values get preserved in conversions, e.g. in OpenAPI `examples` and specification extensions.

If this causes problems it will probably be better to re-add within the relevant format adaptor(s).