### PR TITLE
Fix openapi_3 discriminator schema name mapping to swagger_2

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -322,8 +322,40 @@ Converter.prototype.convertDiscriminatorMapping = function(mapping) {
             continue;
         }
 
-        const schema = this.resolveReference(this.spec, {$ref: schemaNameOrRef})
-            || this.resolveReference(this.spec, {$ref: `#/components/schemas/${schemaNameOrRef}`});
+        // payload may be a schema name or JSON Reference string.
+        // OAS3 spec limits schema names to ^[a-zA-Z0-9._-]+$
+        // Note: Valid schema name could be JSON file name without extension.
+        //       Prefer schema name, with file name as fallback.
+        let schema;
+        if (/^[a-zA-Z0-9._-]+$/.test(schemaNameOrRef)) {
+            try {
+                schema = this.resolveReference(
+                    this.spec,
+                    {$ref: `#/components/schemas/${schemaNameOrRef}`}
+                );
+            } catch (err) {
+                console.debug(
+                    `Error resolving ${schemaNameOrRef} for ${payload
+                    } as schema name in discriminator.mapping: ${err}`
+                );
+            }
+        }
+
+        // schemaNameRef is not a schema name.  Try to resolve as JSON Ref.
+        if (!schema) {
+            try {
+                schema = this.resolveReference(
+                    this.spec,
+                    {$ref: schemaNameOrRef}
+                );
+            } catch (err) {
+                console.debug(
+                    `Error resolving ${schemaNameOrRef} for ${payload
+                    } in discriminator.mapping: ${err}`
+                );
+            }
+        }
+
         if (schema) {
             // Swagger Codegen + OpenAPI Generator extension
             // https://github.com/swagger-api/swagger-codegen/pull/4252

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -44,6 +44,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "Canine": "Dog",
             "Feline": "#/components/schemas/Cat"
           }
         },
@@ -71,6 +72,24 @@
             },
             "required": [
               "likesMilk"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/Animal"
+          }
+        ]
+      },
+      "Dog": {
+        "allOf": [
+          {
+            "properties": {
+              "chasesMailman": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "chasesMailman"
             ],
             "type": "object"
           },

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -37,6 +37,26 @@
       "x-discriminator-value": "Feline",
       "x-ms-discriminator-value": "Feline"
     },
+    "Dog": {
+      "allOf": [
+        {
+          "properties": {
+            "chasesMailman": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "chasesMailman"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "x-discriminator-value": "Canine",
+      "x-ms-discriminator-value": "Canine"
+    },
     "Category": {
       "properties": {
         "id": {


### PR DESCRIPTION
The OpenAPI 3 Specification defines the mapping property of the Discriminator object as ["An object to hold mappings between payload values and schema names or references."][1]  When the mapping contained a schema name, the previous code (that I wrote, whoops) would crash with

    Error: Remote $ref URLs are not currently supported for openapi_3

Update the code to correctly handle schema names and to handle resolution errors more gracefully.  Update tests to cover this.

Thanks for considering,
Kevin

Ref: #206

[1]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminator-object