### PR TITLE
Allow optional URL host and schemes fields.

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -101,7 +101,7 @@ Converter.prototype.convertInfos = function() {
             delete this.spec.host;
             this.spec.basePath = url.pathname;
         } else {
-            this.spec.schemes = [url.protocol];
+            this.spec.schemes = [url.protocol.substring(0, url.protocol.length - 1)];  // strip off trailing colon
             this.spec.host = url.host;
             this.spec.basePath = url.pathname;
         }

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -14,6 +14,7 @@ var npath = require('path');
 var fs = require('fs');
 var urlParser = require('url');
 var YAML = require('js-yaml');
+var { URL } = require('url');
 
 /**
  * Transforms OpenApi 3.0 to Swagger 2
@@ -94,11 +95,15 @@ Converter.prototype.resolveReference = function(base, obj) {
 Converter.prototype.convertInfos = function() {
     var server = this.spec.servers && this.spec.servers[0];
     if (server) {
-        var match = server.url.match(/(\w+):\/\/([^\/]+)(\/.*)?/);
-        if (match) {
-          this.spec.schemes = [match[1]];
-          this.spec.host = match[2];
-          this.spec.basePath = match[3] || '/';
+        var url = new URL(server.url, 'https://example.com');
+        if (url.host == 'example.com') {
+            delete this.spec.schemes;
+            delete this.spec.host;
+            this.spec.basePath = url.pathname;
+        } else {
+            this.spec.schemes = [url.protocol];
+            this.spec.host = url.host;
+            this.spec.basePath = url.pathname;
         }
     }
     delete this.spec.servers;

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -14,7 +14,6 @@ var npath = require('path');
 var fs = require('fs');
 var urlParser = require('url');
 var YAML = require('js-yaml');
-var { URL } = require('url');
 
 /**
  * Transforms OpenApi 3.0 to Swagger 2
@@ -95,16 +94,18 @@ Converter.prototype.resolveReference = function(base, obj) {
 Converter.prototype.convertInfos = function() {
     var server = this.spec.servers && this.spec.servers[0];
     if (server) {
-        var url = new URL(server.url, 'https://example.com');
-        if (url.host == 'example.com') {
-            delete this.spec.schemes;
+        var url = urlParser.parse(server.url);
+        if (url.host == null) {
             delete this.spec.host;
-            this.spec.basePath = url.pathname;
+        } else {
+            this.spec.host = url.host;
+        }
+        if (url.protocol == null) {
+            delete this.spec.schemes;
         } else {
             this.spec.schemes = [url.protocol.substring(0, url.protocol.length - 1)];  // strip off trailing colon
-            this.spec.host = url.host;
-            this.spec.basePath = url.pathname;
         }
+        this.spec.basePath = url.pathname;
     }
     delete this.spec.servers;
     delete this.spec.openapi;


### PR DESCRIPTION
The OpenAPI 3 [server object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#server-object) url may be relative, i.e. without scheme and host. The Swagger 2 [Swagger object](https://swagger.io/specification/v2/#swagger-object) host and schemes fields are optional.

This PR allows scheme and host to be optional.