### PR TITLE
Allow external document references

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -73,7 +73,8 @@ Converter.prototype.resolveReference = function(base, obj) {
   } else if (ref.startsWith('http') || !this.directory) {
     throw new Error("Remote $ref URLs are not currently supported for openapi_3");
   } else {
-    let content = fs.readFileSync(npath.join(this.directory, ref), 'utf8');
+    var res = ref.split('#/', 2);
+    let content = fs.readFileSync(npath.join(this.directory, res[0]), 'utf8');
     let external = null;
     try {
       external = JSON.parse(content);
@@ -81,8 +82,12 @@ Converter.prototype.resolveReference = function(base, obj) {
       try {
         external = YAML.safeLoad(content);
       } catch (e) {
-        throw new Error("Could not parse $ref " + ref + " as JSON or YAML");
+        throw new Error("Could not parse path of $ref " + res[0] + " as JSON or YAML");
       }
+    }
+    if (res.length > 1) {
+      var keys = res[1].split('/').map(k => k.replace(/~1/g, '/').replace(/~0/g, '~'));
+      keys.forEach(function(k) { external = external[k] });
     }
     return external;
   }

--- a/test/input/openapi_3/external_ref_fragment.json
+++ b/test/input/openapi_3/external_ref_fragment.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.0.0",
+  "responses": {
+    "Error": {
+      "description": "Error response"
+    }
+  }
+}
+

--- a/test/input/openapi_3/has_external_ref.json
+++ b/test/input/openapi_3/has_external_ref.json
@@ -18,6 +18,9 @@
                             }
                         },
                         "description": "Successful response"
+                    },
+                    "default": {
+                        "$ref": "./external_ref_fragment.json#/responses/Error"
                     }
                 },
                 "summary": "Get all",

--- a/test/output/swagger_2/has_external_ref.json
+++ b/test/output/swagger_2/has_external_ref.json
@@ -17,6 +17,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          "default": {
+            "description": "Error response"
           }
         },
         "summary": "Get all",


### PR DESCRIPTION
JSON References may reference properties with external documents as part of the URI fragment as per https://swagger.io/docs/specification/using-ref/ and https://swagger.io/specification/v2/#relative-files-with-embedded-schema-example