### PR TITLE
openapi_3 to 2: Convert deprecated to x-deprecated

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -353,6 +353,16 @@ Converter.prototype.convertSchema = function(def) {
         def['x-nullable'] = true;
         delete def.nullable;
     }
+
+    // OpenAPI 3 has boolean "deprecated" on Schema, OpenAPI 2 does not
+    // Convert to x-deprecated for Autorest (and perhaps others)
+    if (def['deprecated'] !== undefined) {
+        // Move to x-deprecated, unless it is already defined
+        if (def['x-deprecated'] === undefined) {
+            def['x-deprecated'] = def.deprecated;
+        }
+        delete def.deprecated;
+    }
 }
 
 Converter.prototype.convertSchemas = function() {

--- a/test/input/openapi_3/deprecated.yml
+++ b/test/input/openapi_3/deprecated.yml
@@ -1,0 +1,80 @@
+openapi: 3.0.0
+info:
+  version: 0.0.1
+  title: >-
+    API with deprecated schemas and operations
+
+    See https://github.com/Azure/autorest/tree/master/Samples/test/deprecated
+    for description of x-deprecated as supported by Autorest
+paths:
+  /path1:
+    get:
+      deprecated: true
+      responses:
+        '200':
+          description: Deprecated operation 1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schema1'
+      operationId: getPath1
+  /path2:
+    get:
+      deprecated: true
+      x-deprecated:
+        description: Deprecation info
+      responses:
+        '200':
+          description: Deprecated operation 2
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schema2'
+      operationId: getPath2
+  /path3:
+    get:
+      responses:
+        '200':
+          description: Operation 3
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schema3'
+      operationId: getPath3
+components:
+  schemas:
+    Schema1:
+      deprecated: true
+      type: object
+      properties:
+        prop1:
+          x-deprecated:
+            description: Prop deprecation info
+          type: string
+        prop2:
+          deprecated: true
+          x-deprecated:
+            description: Prop also deprecated
+          type: string
+        prop3:
+          deprecated: false
+          type: integer
+    Schema2:
+      deprecated: true
+      x-deprecated:
+        replaced-by: Schema1
+      type: object
+      properties:
+        prop4:
+          deprecated: true
+          type: string
+        prop5:
+          type: array
+          items:
+            deprecated: true
+            type: string
+    Schema3:
+      deprecated: false
+      type: array
+      items:
+        type: string

--- a/test/output/swagger_2/deprecated.yml
+++ b/test/output/swagger_2/deprecated.yml
@@ -1,0 +1,82 @@
+definitions:
+  Schema1:
+    x-deprecated: true
+    type: object
+    properties:
+      prop1:
+        x-deprecated:
+          description: Prop deprecation info
+        type: string
+      prop2:
+        x-deprecated:
+          description: Prop also deprecated
+        type: string
+      prop3:
+        x-deprecated: false
+        type: integer
+  Schema2:
+    x-deprecated:
+      replaced-by: Schema1
+    type: object
+    properties:
+      prop4:
+        x-deprecated: true
+        type: string
+      prop5:
+        type: array
+        items:
+          x-deprecated: true
+          type: string
+  Schema3:
+    x-deprecated: false
+    type: array
+    items:
+      type: string
+info:
+  title: >-
+    API with deprecated schemas and operations
+
+    See https://github.com/Azure/autorest/tree/master/Samples/test/deprecated
+    for description of x-deprecated as supported by Autorest
+  version: 0.0.1
+paths:
+  /path1:
+    get:
+      deprecated: true
+      operationId: getPath1
+      parameters: []
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Deprecated operation 1
+          schema:
+            $ref: '#/definitions/Schema1'
+  /path2:
+    get:
+      deprecated: true
+      operationId: getPath2
+      parameters: []
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Deprecated operation 2
+          schema:
+            $ref: '#/definitions/Schema2'
+      x-deprecated:
+        description: Deprecation info
+  /path3:
+    get:
+      responses:
+        '200':
+          description: Operation 3
+          schema:
+            $ref: '#/definitions/Schema3'
+      operationId: getPath3
+      parameters: []
+      produces:
+      - application/json
+swagger: '2.0'
+x-components: {}
+

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -59,6 +59,12 @@ TestCases.push({
 })
 
 TestCases.push({
+  in: {format: 'openapi_3', file: 'deprecated.yml'},
+  out: {format: 'swagger_2', file: 'deprecated.yml'},
+  skipBrowser: true,
+})
+
+TestCases.push({
   in: {format: 'swagger_2', file: 'petstore.json'},
   out: {format: 'openapi_3', file: 'petstore2.json'}
 })


### PR DESCRIPTION
Although both OpenAPI 3 and 2 support the `deprecated` property on Operation objects, only OpenAPI 3 supports `deprecated` on Schema objects. Convert to `x-deprecated` for OpenAPI 2, which is supported by Autorest (and possibly others).  Don't overwrite any existing `x-deprecated` property, which may contain additional deprecation information.

Thanks for considering,
Kevin