### PR TITLE
openapi_3 to 2: $ref parameter missing name+in

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -196,6 +196,12 @@ Converter.prototype.convertParameters = function(obj) {
         if (param.in !== 'body') {
             this.copySchemaProperties(param, SCHEMA_PROPERTIES);
             this.copySchemaProperties(param, ARRAY_PROPERTIES);
+            if (!param.description) {
+                const schema = this.resolveReference(this.spec, param.schema);
+                if (schema.description) {
+                    param.description = schema.description;
+                }
+            }
             delete param.schema;
             delete param.allowReserved;
             if (param.example !== undefined) {

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -148,10 +148,12 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 param.schema = this.resolveReference(this.spec, param.schema);
                 if (param.schema.type === 'object' && param.schema.properties) {
                     for (var name in param.schema.properties) {
-                      var p = param.schema.properties[name];
-                      p.name = name;
-                      p.in = 'formData';
-                      operation.parameters.push(p);
+                        const schema = param.schema.properties[name];
+                        operation.parameters.push({
+                            name,
+                            in: 'formData',
+                            schema,
+                        });
                     }
                 } else {
                     operation.parameters.push(param);

--- a/test/input/openapi_3/form_param.yml
+++ b/test/input/openapi_3/form_param.yml
@@ -14,6 +14,8 @@ paths:
               properties:
                 name:
                   type: string
+                format:
+                  $ref: '#/components/schemas/ImageFormat'
                 image:
                   type: string
                   format: binary
@@ -27,3 +29,11 @@ paths:
       tags:
         - Foos
       operationId: getFoo
+components:
+  schemas:
+    ImageFormat:
+      type: string
+      enum:
+        - gif
+        - jpeg
+        - png

--- a/test/output/swagger_2/form_param.yml
+++ b/test/output/swagger_2/form_param.yml
@@ -1,3 +1,10 @@
+definitions:
+  ImageFormat:
+    type: string
+    enum:
+      - gif
+      - jpeg
+      - png
 info:
   title: test
   version: 0.0.1
@@ -11,6 +18,13 @@ paths:
         - in: formData
           name: name
           type: string
+        - in: formData
+          name: format
+          type: string
+          enum:
+            - gif
+            - jpeg
+            - png
         - format: binary
           in: formData
           name: image
@@ -25,4 +39,4 @@ paths:
       tags:
         - Foos
 swagger: '2.0'
-
+x-components: {}


### PR DESCRIPTION
When converting an OpenAPI 3 document to OpenAPI 2, if the schema for a `formData` parameter is a reference, the name and in properties were added to the `$ref` object then lost when it was resolved.

This commit adds a test case to cover this (using an enum) and avoids the issue by resolving (and cloning) the schema before assigning name and in.

Thanks for considering,
Kevin