### PR TITLE
openapi_3 to 2: Skip readOnly formData params

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -149,11 +149,14 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 if (param.schema.type === 'object' && param.schema.properties) {
                     for (var name in param.schema.properties) {
                         const schema = param.schema.properties[name];
-                        operation.parameters.push({
-                            name,
-                            in: 'formData',
-                            schema,
-                        });
+                        // readOnly properties should not be sent in requests
+                        if (!schema.readOnly) {
+                            operation.parameters.push({
+                                name,
+                                in: 'formData',
+                                schema,
+                            });
+                        }
                     }
                 } else {
                     operation.parameters.push(param);

--- a/test/input/openapi_3/form_param.yml
+++ b/test/input/openapi_3/form_param.yml
@@ -16,6 +16,10 @@ paths:
                   type: string
                 format:
                   $ref: '#/components/schemas/ImageFormat'
+                uploadDate:
+                  type: string
+                  format: date-time
+                  readOnly: true
                 image:
                   type: string
                   format: binary


### PR DESCRIPTION
The readOnly property in OAS3 declares that a schema property

> MAY be sent as part of a response but SHOULD NOT be sent as part of the request

When converting properties to `formData` parameters, skip `readOnly` properties, since they should not be sent as parameters.

Add a test to cover this.

Note: This PR should apply after #230.  Only the last commit is specific to this PR.

Thanks for considering,
Kevin