### PR TITLE
openapi_3 to 2: Copy x- props from schema to param

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -198,6 +198,7 @@ Converter.prototype.convertParameters = function(obj) {
         if (param.in !== 'body') {
             this.copySchemaProperties(param, SCHEMA_PROPERTIES);
             this.copySchemaProperties(param, ARRAY_PROPERTIES);
+            this.copySchemaXProperties(param);
             if (!param.description) {
                 const schema = this.resolveReference(this.spec, param.schema);
                 if (schema.description) {
@@ -250,6 +251,18 @@ Converter.prototype.copySchemaProperties = function(obj, props) {
         }
     });
 }
+
+Converter.prototype.copySchemaXProperties = function(obj) {
+    let schema = this.resolveReference(this.spec, obj.schema);
+    if (!schema) return;
+    for (const propName in schema) {
+        if (hasOwnProperty.call(schema, propName)
+            && !hasOwnProperty.call(obj, propName)
+            && propName.startsWith('x-')) {
+            obj[propName] = schema[propName];
+        }
+    }
+};
 
 Converter.prototype.convertResponses = function(operation) {
     var anySchema, code, content, jsonSchema, mediaRange, mediaType, response, resolved, headers;

--- a/test/input/openapi_3/form_param.yml
+++ b/test/input/openapi_3/form_param.yml
@@ -37,3 +37,6 @@ components:
         - gif
         - jpeg
         - png
+      x-ms-enum:
+        name: ImageType
+        modelAsString: true

--- a/test/output/swagger_2/form_param.yml
+++ b/test/output/swagger_2/form_param.yml
@@ -5,6 +5,9 @@ definitions:
       - gif
       - jpeg
       - png
+    x-ms-enum:
+      name: ImageType
+      modelAsString: true
 info:
   title: test
   version: 0.0.1
@@ -25,6 +28,9 @@ paths:
             - gif
             - jpeg
             - png
+          x-ms-enum:
+            name: ImageType
+            modelAsString: true
         - format: binary
           in: formData
           name: image


### PR DESCRIPTION
The parameter in OpenAPI/Swagger 2 has the properties of schema, excluding properties which define objects, and acts like schema.  When translating, copy schema extension properties which are applicable to parameters.  Since I'm not aware of any which are incompatible, copy them all for now.
    
Add `x-ms-enum` to test.  Note that [Autorest](https://github.com/Azure/autorest) uses the same generated enum type for multiple parameters (and schemas) with the same `x-ms-enum.name` and values, so duplication is not an issue.

Note: This PR should apply after #231.  Only the last commit is specific to this PR.

Thanks for considering,
Kevin