### PR TITLE
openapi_3 to 2: Set required for formData params

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -147,15 +147,20 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 param.schema = content[contentKey].schema;
                 param.schema = this.resolveReference(this.spec, param.schema);
                 if (param.schema.type === 'object' && param.schema.properties) {
+                    const required = param.schema.required || [];
                     for (var name in param.schema.properties) {
                         const schema = param.schema.properties[name];
                         // readOnly properties should not be sent in requests
                         if (!schema.readOnly) {
-                            operation.parameters.push({
+                            const formDataParam = {
                                 name,
                                 in: 'formData',
                                 schema,
-                            });
+                            };
+                            if (required.indexOf(name) >= 0) {
+                                formDataParam.required = true;
+                            }
+                            operation.parameters.push(formDataParam);
                         }
                     }
                 } else {

--- a/test/input/openapi_3/form_param.yml
+++ b/test/input/openapi_3/form_param.yml
@@ -23,6 +23,8 @@ paths:
                 image:
                   type: string
                   format: binary
+              required:
+              - image
       responses:
         '200':
           description: Foo

--- a/test/output/swagger_2/form_param.yml
+++ b/test/output/swagger_2/form_param.yml
@@ -35,6 +35,7 @@ paths:
           in: formData
           name: image
           type: string
+          required: true
       produces:
         - application/json
       responses:


### PR DESCRIPTION
When converting schema properties to parameters in formData, if the property is required, make the parameter required, since these have the same meaning.

Thanks for considering,
Kevin