### PR TITLE
add support for openapi_3 server variables

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -104,7 +104,7 @@ Converter.prototype.convertInfos = function() {
         for (var variable in variables) {
             var variableObject = variables[variable] || {};
             if (variableObject['default']) {
-                var re = RegExp('\{' + variable + '\}', 'g');
+                var re = RegExp('{' + variable + '}', 'g');
                 serverUrl = serverUrl.replace(re, variableObject['default']);
             }
         }

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -99,7 +99,16 @@ Converter.prototype.resolveReference = function(base, obj) {
 Converter.prototype.convertInfos = function() {
     var server = this.spec.servers && this.spec.servers[0];
     if (server) {
-        var url = urlParser.parse(server.url);
+        var serverUrl = server.url,
+            variables = server['variables'] || {};
+        for (var variable in variables) {
+            var variableObject = variables[variable] || {};
+            if (variableObject['default']) {
+                var re = RegExp('\{' + variable + '\}', 'g');
+                serverUrl = serverUrl.replace(re, variableObject['default']);
+            }
+        }
+        var url = urlParser.parse(serverUrl);
         if (url.host == null) {
             delete this.spec.host;
         } else {

--- a/test/input/openapi_3/servers.yml
+++ b/test/input/openapi_3/servers.yml
@@ -1,0 +1,14 @@
+openapi: 3.0.1
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+servers:
+  - url: '{scheme}://{host}{basePath}'
+    variables:
+      scheme: 
+        default: https
+      host:
+        default: api.example.com
+      basePath:
+        default: /api

--- a/test/output/swagger_2/servers.json
+++ b/test/output/swagger_2/servers.json
@@ -1,0 +1,13 @@
+{
+  "basePath": "/api",
+  "host": "api.example.com",
+  "schemes": [
+    "https"
+  ],
+  "info": {
+    "description": "API description in Markdown.",
+    "title": "Sample API",
+    "version": "1.0.0"
+  },
+  "swagger": "2.0"
+}

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -90,6 +90,11 @@ TestCases.push({
 })
 
 TestCases.push({
+  in: {format: 'openapi_3', file: 'servers.yml'},
+  out: {format: 'swagger_2', file: 'servers.json'}
+})
+
+TestCases.push({
   in: {format: 'openapi_3', file: 'slash_ref.yml'},
   out: {format: 'swagger_2', file: 'slash_ref.json'}
 })


### PR DESCRIPTION
This PR implements support for OpenAPI 3 server variables for templated server URLs and using default values to populate the URL.

Currently, conversion to 2.0 fails for server objects using templated URLs and variables.