### PR TITLE
Resolve issue #248

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,13 @@ Contributions are welcome and encouraged.
 Please add a test case if you're adding features or fixing bugs. To run the tests:
 
 ```bash
-WRITE_GOLDEN=true npm test
+npm test
 ```
 
+In case you need to override the expected outputs, due to a justified and verified change, run this:
+```bash
+WRITE_GOLDEN=true npm test
+```
 ### Releases
 ```
 npm run browserify

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -1,4 +1,5 @@
 "use strict";
+const cloneDeep = require('lodash.clonedeep');
 
 var HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'],
     SCHEMA_PROPERTIES = ['format', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'minLength', 'maxLength', 'multipleOf', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'additionalProperties', 'pattern', 'enum', 'default'],
@@ -61,7 +62,7 @@ function fixRefs(obj) {
   }
 }
 
-Converter.prototype.resolveReference = function(base, obj) {
+Converter.prototype.resolveReference = function(base, obj, shouldClone) {
   if (!obj || !obj.$ref) return obj;
   var ref = obj.$ref;
   if (ref.startsWith('#')) {
@@ -69,7 +70,7 @@ Converter.prototype.resolveReference = function(base, obj) {
     keys.shift();
     var cur = base;
     keys.forEach(function(k) { cur = cur[k] });
-    return cur;
+    return shouldClone ? cloneDeep(cur) : cur;
   } else if (ref.startsWith('http') || !this.directory) {
     throw new Error("Remote $ref URLs are not currently supported for openapi_3");
   } else {
@@ -128,11 +129,11 @@ Converter.prototype.convertInfos = function() {
 Converter.prototype.convertOperations = function() {
     var path, pathObject, method, operation;
     for (path in this.spec.paths) {
-        pathObject = this.spec.paths[path] = this.resolveReference(this.spec, this.spec.paths[path]);
+        pathObject = this.spec.paths[path] = this.resolveReference(this.spec, this.spec.paths[path], true);
         this.convertParameters(pathObject); // converts common parameters
         for (method in pathObject) {
             if (HTTP_METHODS.indexOf(method) >= 0) {
-                operation = pathObject[method] = this.resolveReference(this.spec, pathObject[method]);
+                operation = pathObject[method] = this.resolveReference(this.spec, pathObject[method], true);
                 this.convertOperationParameters(operation);
                 this.convertResponses(operation);
             }
@@ -144,7 +145,7 @@ Converter.prototype.convertOperationParameters = function(operation) {
     var content, param, contentKey, mediaRanges, mediaTypes;
     operation.parameters = operation.parameters || [];
     if (operation.requestBody) {
-        param = this.resolveReference(this.spec, operation.requestBody);
+        param = this.resolveReference(this.spec, operation.requestBody, true);
 
         // fixing external $ref in body
         if (operation.requestBody.content) {
@@ -153,7 +154,7 @@ Converter.prototype.convertOperationParameters = function(operation) {
             let data = operation.requestBody.content[type];
 
             if (data && data.schema && data.schema.$ref && !data.schema.$ref.startsWith('#')) {
-                param = this.resolveReference(this.spec, data.schema);
+                param = this.resolveReference(this.spec, data.schema, true);
                 structuredObj['content'][`${type}`] = {'schema': param};
                 param = structuredObj
             }
@@ -173,7 +174,7 @@ Converter.prototype.convertOperationParameters = function(operation) {
                 operation.consumes = mediaTypes;
                 param.in = 'formData';
                 param.schema = content[contentKey].schema;
-                param.schema = this.resolveReference(this.spec, param.schema);
+                param.schema = this.resolveReference(this.spec, param.schema, true);
                 if (param.schema.type === 'object' && param.schema.properties) {
                     const required = param.schema.required || [];
                     for (var name in param.schema.properties) {
@@ -230,13 +231,13 @@ Converter.prototype.convertParameters = function(obj) {
     obj.parameters = obj.parameters || [];
 
     (obj.parameters || []).forEach((param, i) => {
-        param = obj.parameters[i] = this.resolveReference(this.spec, param);
+        param = obj.parameters[i] = this.resolveReference(this.spec, param, false);
         if (param.in !== 'body') {
             this.copySchemaProperties(param, SCHEMA_PROPERTIES);
             this.copySchemaProperties(param, ARRAY_PROPERTIES);
             this.copySchemaXProperties(param);
             if (!param.description) {
-                const schema = this.resolveReference(this.spec, param.schema);
+                const schema = this.resolveReference(this.spec, param.schema, false);
                 if (!!schema && schema.description) {
                     param.description = schema.description;
                 }
@@ -272,7 +273,7 @@ Converter.prototype.convertParameters = function(obj) {
 }
 
 Converter.prototype.copySchemaProperties = function(obj, props) {
-    let schema = this.resolveReference(this.spec, obj.schema);
+    let schema = this.resolveReference(this.spec, obj.schema, true);
     if (!schema) return;
     props.forEach(function(prop) {
         var value = schema[prop];
@@ -289,7 +290,7 @@ Converter.prototype.copySchemaProperties = function(obj, props) {
 }
 
 Converter.prototype.copySchemaXProperties = function(obj) {
-    let schema = this.resolveReference(this.spec, obj.schema);
+    let schema = this.resolveReference(this.spec, obj.schema, true);
     if (!schema) return;
     for (const propName in schema) {
         if (hasOwnProperty.call(schema, propName)
@@ -303,7 +304,7 @@ Converter.prototype.copySchemaXProperties = function(obj) {
 Converter.prototype.convertResponses = function(operation) {
     var anySchema, code, content, jsonSchema, mediaRange, mediaType, response, resolved, headers;
     for (code in operation.responses) {
-        response = operation.responses[code] = this.resolveReference(this.spec, operation.responses[code]);
+        response = operation.responses[code] = this.resolveReference(this.spec, operation.responses[code], true);
         if (response.content) {
             anySchema = jsonSchema = null;
             for (mediaRange in response.content) {
@@ -332,7 +333,7 @@ Converter.prototype.convertResponses = function(operation) {
 
             if (anySchema) {
                 response.schema = jsonSchema || anySchema;
-                resolved = this.resolveReference(this.spec, response.schema);
+                resolved = this.resolveReference(this.spec, response.schema, true);
                 if (resolved
                     && response.schema.$ref
                     && !response.schema.$ref.startsWith('#')) {
@@ -347,7 +348,7 @@ Converter.prototype.convertResponses = function(operation) {
         if (headers) {
             for (var header in headers) {
                 // Always resolve headers when converting to v2.
-                resolved = this.resolveReference(this.spec, headers[header])
+                resolved = this.resolveReference(this.spec, headers[header], true)
                 // Headers should be converted like parameters.
                 if (resolved.schema){
                     resolved.type = resolved.schema.type
@@ -454,7 +455,8 @@ Converter.prototype.convertDiscriminatorMapping = function(mapping) {
             try {
                 schema = this.resolveReference(
                     this.spec,
-                    {$ref: `#/components/schemas/${schemaNameOrRef}`}
+                    {$ref: `#/components/schemas/${schemaNameOrRef}`},
+                    false
                 );
             } catch (err) {
                 console.debug(
@@ -469,7 +471,8 @@ Converter.prototype.convertDiscriminatorMapping = function(mapping) {
             try {
                 schema = this.resolveReference(
                     this.spec,
-                    {$ref: schemaNameOrRef}
+                    {$ref: schemaNameOrRef},
+                    false
                 );
             } catch (err) {
                 console.debug(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3873,6 +3873,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "deep-sort-object": "^1.0.2",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.11",
+    "lodash.clonedeep": "^4.5.0",
     "request": "^2.88.2",
     "source-map": "0.6.0",
     "sway": "^2.0.5",

--- a/test/input/openapi_3/multiple_ref.yml
+++ b/test/input/openapi_3/multiple_ref.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: test
+  description: |-
+    test
+  version: "2"
+paths:
+  /testBodyRefIsResolved:
+    post:
+      summary: test
+      description: |-
+        test
+      responses:
+        '200':
+          description: |-
+            ok
+      requestBody:
+        $ref: '#/components/requestBodies/Value'
+  /testSameBodyRefIsResolvedAgain:
+    post:
+      summary: test
+      description: |-
+        test
+      responses:
+        '200':
+          description: |-
+            ok
+      requestBody:
+        $ref: '#/components/requestBodies/Value'
+servers:
+  - url: https://somewhere.test
+    description: above the clouds
+components:
+  requestBodies:
+    Value:
+      content:
+        application/json:
+          schema:
+            type: object
+            example: {}
+      description: |-
+        Some content
+      required: true

--- a/test/output/swagger_2/multiple_ref.json
+++ b/test/output/swagger_2/multiple_ref.json
@@ -1,0 +1,83 @@
+{
+  "basePath": "/",
+  "host": "somewhere.test",
+  "info": {
+    "description": "test",
+    "title": "test",
+    "version": "2"
+  },
+  "paths": {
+    "/testBodyRefIsResolved": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "test",
+        "parameters": [
+          {
+            "description": "Some content",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "example": {},
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        },
+        "summary": "test"
+      }
+    },
+    "/testSameBodyRefIsResolvedAgain": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "test",
+        "parameters": [
+          {
+            "description": "Some content",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "example": {},
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        },
+        "summary": "test"
+      }
+    }
+  },
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0",
+  "x-components": {
+    "requestBodies": {
+      "Value": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "example": {},
+              "type": "object"
+            }
+          }
+        },
+        "description": "Some content",
+        "required": true
+      }
+    }
+  }
+}

--- a/test/output/swagger_2/param_schema_ref.json
+++ b/test/output/swagger_2/param_schema_ref.json
@@ -59,10 +59,14 @@
   "x-components": {
     "responses": {
       "defaultResponse": {
-        "description": "Success",
-        "schema": {
-          "$ref": "#/definitions/DefaultResponseObject"
-        }
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/definitions/DefaultResponseObject"
+            }
+          }
+        },
+        "description": "Success"
       }
     }
   }

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -814,8 +814,24 @@
     },
     "/user/createWithList": {
       "post": {
+        "consumes": [
+          "application/json"
+        ],
         "operationId": "createUsersWithListInput",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "List of user object",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/User"
+              },
+              "type": "array"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "No response was specified"
@@ -1089,32 +1105,40 @@
     "headers": {
       "X-RateLimit-Limit": {
         "description": "The number of allowed requests in the current period",
-        "format": "int32",
-        "type": "integer"
+        "schema": {
+          "format": "int32",
+          "type": "integer"
+        }
       },
       "X-RateLimit-Remaining": {
         "description": "The number of remaining requests in the current period",
-        "format": "int32",
-        "type": "integer"
+        "schema": {
+          "format": "int32",
+          "type": "integer"
+        }
       },
       "X-RateLimit-Reset": {
         "description": "The number of seconds left in the current period",
-        "format": "int32",
-        "type": "integer"
+        "schema": {
+          "format": "int32",
+          "type": "integer"
+        }
       }
     },
     "requestBodies": {
       "UserArray": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/User"
+              },
+              "type": "array"
+            }
+          }
+        },
         "description": "List of user object",
-        "in": "body",
-        "name": "body",
-        "required": true,
-        "schema": {
-          "items": {
-            "$ref": "#/definitions/User"
-          },
-          "type": "array"
-        }
+        "required": true
       }
     }
   }

--- a/test/output/swagger_2/request_response_ref.yml
+++ b/test/output/swagger_2/request_response_ref.yml
@@ -55,34 +55,36 @@ swagger: '2.0'
 x-components:
   requestBodies:
     FooRequest:
-      in: body
-      name: body
+      content:
+        application/json:
+          schema:
+            properties:
+              name:
+                nullable: true
+                type: string
+              pet:
+                allOf:
+                  - $ref: '#/definitions/PetName'
+                  - properties:
+                      favorite_foods:
+                        items:
+                          nullable: true
+                          type: string
+                        type: array
+                    type: object
+            type: object
       required: true
-      schema:
-        properties:
-          name:
-            type: string
-            x-nullable: true
-          pet:
+  responses:
+    FooResponse:
+      content:
+        application/json:
+          schema:
             allOf:
               - $ref: '#/definitions/PetName'
               - properties:
-                  favorite_foods:
-                    items:
-                      type: string
-                      x-nullable: true
-                    type: array
+                  name:
+                    nullable: true
+                    type: string
                 type: object
-        type: object
-  responses:
-    FooResponse:
       description: Foo
-      schema:
-        allOf:
-          - $ref: '#/definitions/PetName'
-          - properties:
-              name:
-                type: string
-                x-nullable: true
-            type: object
 

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -141,6 +141,12 @@ TestCases.push({
   skipBrowser: true,
 })
 
+TestCases.push({
+  in: {format: 'openapi_3', file: 'multiple_ref.yml'},
+  out: {format: 'swagger_2', file: 'multiple_ref.json', syntax: 'json'},
+  skipBrowser: true,
+})
+
 var openapi3Cases = [];
 
 TestCases.forEach(function(testCase) {


### PR DESCRIPTION
Reopening this PR as per your request.

Re the test output - quoting the comment in the commit message:

"This changes the resolve mechanism to clone the resolved entity before returning it, so that changes applied to it in the code that is using it, won't affect the component it references (and thus will not modify it and prevent it from being resolved in later occasions).

This change makes the x-component entities look like they originally were (unmodified), and this complies with the swagger 2 syntax, since their definition resides inside the extension property (see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#specification-extensions)."