### PR TITLE
Adding option to prevent sorting

### DIFF
--- a/lib/base_format.js
+++ b/lib/base_format.js
@@ -53,30 +53,35 @@ BaseFormat.prototype.stringify = function(options) {
   syntax = syntax || 'json';     // other value 'yaml'
   order  = order  || 'openapi';  // other value 'alpha' for a-z alphabetical order
 
-  var sortedSpecs = SortObject(this.spec, function (a, b) {
-    var aIdx = -1
-    var bIdx = -1
+  if (order == 'false') {
+    sortedSpecs = this.spec
+  }
+  else {
+    var sortedSpecs = SortObject(this.spec, function (a, b) {
+      var aIdx = -1
+      var bIdx = -1
 
-    if(order != 'alpha'){
-      // do index lookup only if it will be used; i.e. for OpenApi ordering
-      aIdx = attr.indexOf(a)
-      bIdx = attr.indexOf(b)
-    }
+      if (order != 'alpha') {
+        // do index lookup only if it will be used; i.e. for OpenApi ordering
+        aIdx = attr.indexOf(a)
+        bIdx = attr.indexOf(b)
+      }
 
-    // if none of the args to compare are in the pre-sorted list
-    // use the normal alphabetical sort
-    if (aIdx == -1 && bIdx == -1) {
+      // if none of the args to compare are in the pre-sorted list
+      // use the normal alphabetical sort
+      if (aIdx == -1 && bIdx == -1) {
         //By default sort is done using local aware compare
         //Instead using order that will never change
         if (a === b)
           return 0;
         return (a < b) ? -1 : 1;
-    }
+      }
 
-    // sort according to index in attr pre-sorted list
-    if (aIdx === bIdx) return 0;
-    return aIdx < bIdx ? 1 : -1;
-  });
+      // sort according to index in attr pre-sorted list
+      if (aIdx === bIdx) return 0;
+      return aIdx < bIdx ? 1 : -1;
+    });
+  }
 
   if (syntax == "yaml") {
     return Yaml.safeDump(sortedSpecs)

--- a/test/output/swagger_2/param_schema_unordered_ref.json
+++ b/test/output/swagger_2/param_schema_unordered_ref.json
@@ -1,0 +1,73 @@
+{
+  "info": {
+    "title": "testsickle",
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/user/account/{accountLevel}": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountLevel",
+            "required": true,
+            "enum": [
+              "one",
+              "two",
+              "three",
+              "four"
+            ],
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/DefaultResponseObject"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "swagger": "2.0",
+  "definitions": {
+    "accountLevel": {
+      "type": "string",
+      "enum": [
+        "one",
+        "two",
+        "three",
+        "four"
+      ]
+    },
+    "DefaultResponseObject": {
+      "required": [
+        "message"
+      ],
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-components": {
+    "responses": {
+      "defaultResponse": {
+        "description": "Success",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/definitions/DefaultResponseObject"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -180,8 +180,8 @@ SyntaxTestCases.push({
 
 SyntaxTestCases.push({
   in: {format: 'openapi_3', file: 'param_schema_ref.yml'},
-  out: {format: 'swagger_2', file: 'param_schema_unordered_ref.json', order: 'false '}
-})
+  out: {format: 'swagger_2', file: 'param_schema_unordered_ref.json', order: 'false'}
+})  
 
 //---- exports ----
 

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -180,7 +180,7 @@ SyntaxTestCases.push({
 
 SyntaxTestCases.push({
   in: {format: 'openapi_3', file: 'param_schema_ref.yml'},
-  out: {format: 'swagger_2', file: 'param_schema_unordered_ref.json', order: 'false'}
+  out: {format: 'swagger_2', file: 'param_schema_unordered_ref.json', order: 'false '}
 })
 
 //---- exports ----

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -178,6 +178,11 @@ SyntaxTestCases.push({
   out: {format: 'swagger_2', file: 'petstore-oa.yaml', syntax: 'yaml', order: 'openapi'}
 })
 
+SyntaxTestCases.push({
+  in: {format: 'openapi_3', file: 'param_schema_ref.yml'},
+  out: {format: 'swagger_2', file: 'param_schema_unordered_ref.json', order: 'false'}
+})
+
 //---- exports ----
 
 if (typeof module !== 'undefined') {


### PR DESCRIPTION
In my company, there is a complaining from the developers that their parameters was being ordered in the conversion, so i think this option should be nice.