### PR TITLE
Keep x-args in securityScheme flow when converting OA3 to SW2

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -524,6 +524,12 @@ Converter.prototype.convertSecurityDefinitions = function() {
             security.tokenUrl = flow.tokenUrl;
             security.scopes = flow.scopes;
             delete security.flows;
+            // copy x- args from the flow as they are
+            Object.keys(flow).forEach(function (k) {
+                if (/^x-/i.test(k)) {
+                    security[k] = flow[k]
+                }
+            })
         }
     }
     delete this.spec.components.securitySchemes;

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -247,7 +247,8 @@
               "read:pets": "Read your pets",
               "write:pets": "Modify pets in your account"
             },
-            "tokenUrl": "http://petstore.swagger.wordnik.com/api/oauth/token"
+            "tokenUrl": "http://petstore.swagger.wordnik.com/api/oauth/token",
+            "x-pet-lover-validator": "On"
           }
         },
         "type": "oauth2"

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -1074,7 +1074,8 @@
         "write:pets": "Modify pets in your account"
       },
       "tokenUrl": "http://petstore.swagger.wordnik.com/api/oauth/token",
-      "type": "oauth2"
+      "type": "oauth2",
+      "x-pet-lover-validator": "On"
     },
     "oauth2_implicit": {
       "authorizationUrl": "http://petstore.swagger.wordnik.com/api/oauth/dialog",


### PR DESCRIPTION
Useful when converting OA3 to SW2 to use in Google Cloud Endpoints configuration